### PR TITLE
feat: add comulative data for volume and trades

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -444,6 +444,15 @@ export const DASHBOARD_COMULATIVE_DATA = gql`
   }
 `;
 
+export const DASHBOARD_TRANSACTION_HISTORY = gql`
+  query transactions($lastId: ID!, $startTime: Int!) {
+    transactions(first: 1000, where: { id_gt: $lastId, timestamp_gt: $startTime }, orderBy: id, orderDirection: asc) {
+      id
+      timestamp
+    }
+  }
+`;
+
 export const DASHBOARD_CHART = gql`
   query swaprDayDatas($startTime: Int!, $skip: Int!) {
     swaprDayDatas(first: 365, skip: $skip, where: { date_gt: $startTime }, orderBy: date, orderDirection: asc) {

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -435,6 +435,15 @@ export const PAIR_DAY_DATA_BULK = (pairs, startTimestamp) => {
   return gql(queryString);
 };
 
+export const DASHBOARD_COMULATIVE_DATA = gql`
+  query swaprFactories {
+    swaprFactories(first: 1) {
+      totalVolumeUSD
+      txCount
+    }
+  }
+`;
+
 export const DASHBOARD_CHART = gql`
   query swaprDayDatas($startTime: Int!, $skip: Int!) {
     swaprDayDatas(first: 365, skip: $skip, where: { date_gt: $startTime }, orderBy: date, orderDirection: asc) {

--- a/src/components/ComulativeNetworkDataCard/index.js
+++ b/src/components/ComulativeNetworkDataCard/index.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { TYPE } from '../../Theme';
+import { NETWORK_COLORS } from '../../constants';
 import Panel from '../Panel';
 import { Header, Value, Content, Network, NetworkData, Title, Icon } from './styled';
 
@@ -17,7 +18,7 @@ const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
     <Content>
       {networksValues.map(({ network, value }, index) => (
         <NetworkData key={network} margin={index !== networksValues.length - 1}>
-          <Network>{network}</Network>
+          <Network color={NETWORK_COLORS[network]}>{network}</Network>
           <TYPE.main fontSize={15}>{value}</TYPE.main>
         </NetworkData>
       ))}

--- a/src/components/ComulativeNetworkDataCard/index.js
+++ b/src/components/ComulativeNetworkDataCard/index.js
@@ -3,11 +3,10 @@ import React from 'react';
 
 import { TYPE } from '../../Theme';
 import { NETWORK_COLORS } from '../../constants';
-import Panel from '../Panel';
 import { Header, Value, Content, Network, NetworkData, Title, Icon } from './styled';
 
 const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
-  <Panel>
+  <>
     <Header>
       <Title>
         <Icon>{icon}</Icon>
@@ -23,13 +22,13 @@ const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
         </NetworkData>
       ))}
     </Content>
-  </Panel>
+  </>
 );
 
 DataCard.propTypes = {
   title: PropTypes.string.isRequired,
   icon: PropTypes.node,
-  comulativeValue: PropTypes.number,
+  comulativeValue: PropTypes.any,
   networksValues: PropTypes.array,
 };
 

--- a/src/components/ComulativeNetworkDataCard/index.js
+++ b/src/components/ComulativeNetworkDataCard/index.js
@@ -3,22 +3,22 @@ import React from 'react';
 
 import { TYPE } from '../../Theme';
 import Panel from '../Panel';
-import { Header, Value, Content, Network, NetworkData } from './styled';
+import { Header, Value, Content, Network, NetworkData, Title, Icon } from './styled';
 
 const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
   <Panel>
     <Header>
-      <span>
-        {icon}
+      <Title>
+        <Icon>{icon}</Icon>
         <TYPE.header fontSize={16}>{title}</TYPE.header>
-      </span>
+      </Title>
       <Value>{comulativeValue}</Value>
     </Header>
     <Content>
       {networksValues.map(({ network, value }, index) => (
         <NetworkData key={network} margin={index !== networksValues.length - 1}>
           <Network>{network}</Network>
-          <TYPE.main>{value}</TYPE.main>
+          <TYPE.main fontSize={15}>{value}</TYPE.main>
         </NetworkData>
       ))}
     </Content>

--- a/src/components/ComulativeNetworkDataCard/index.js
+++ b/src/components/ComulativeNetworkDataCard/index.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { TYPE } from '../../Theme';
+import Panel from '../Panel';
+import { Header, Value, Content, Network, NetworkData } from './styled';
+
+const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
+  <Panel>
+    <Header>
+      <span>
+        {icon}
+        <TYPE.header fontSize={16}>{title}</TYPE.header>
+      </span>
+      <Value>{comulativeValue}</Value>
+    </Header>
+    <Content>
+      {networksValues.map(({ network, value }, index) => (
+        <NetworkData key={network} margin={index !== networksValues.length - 1}>
+          <Network>{network}</Network>
+          <TYPE.main>{value}</TYPE.main>
+        </NetworkData>
+      ))}
+    </Content>
+  </Panel>
+);
+
+DataCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  icon: PropTypes.node,
+  comulativeValue: PropTypes.number,
+  networksValues: PropTypes.array,
+};
+
+export default DataCard;

--- a/src/components/ComulativeNetworkDataCard/styled.js
+++ b/src/components/ComulativeNetworkDataCard/styled.js
@@ -3,25 +3,40 @@ import styled from 'styled-components';
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   margin-bottom: 16px;
 `;
 
+const Title = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Icon = styled.div`
+  margin-right: 8px;
+`;
+
 const Value = styled.div`
-  font-size: 18px;
+  font-size: 22px;
+  color: ${({ theme }) => theme.text1};
   font-weight: bold;
 `;
 
 const Network = styled.div`
-  font-size: 16px;
+  font-size: 14px;
+  color: ${({ theme }) => theme.text2};
 `;
 
 const Content = styled.div`
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
+  flex-wrap: wrap;
 `;
 
 const NetworkData = styled.div`
   margin-bottom: ${({ margin }) => (margin ? '12px' : '0')};
+  margin-right: 36px;
 `;
 
-export { Header, Value, Network, Content, NetworkData };
+export { Header, Title, Icon, Value, Network, Content, NetworkData };

--- a/src/components/ComulativeNetworkDataCard/styled.js
+++ b/src/components/ComulativeNetworkDataCard/styled.js
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+`;
+
+const Value = styled.div`
+  font-size: 18px;
+  font-weight: bold;
+`;
+
+const Network = styled.div`
+  font-size: 16px;
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const NetworkData = styled.div`
+  margin-bottom: ${({ margin }) => (margin ? '12px' : '0')};
+`;
+
+export { Header, Value, Network, Content, NetworkData };

--- a/src/components/LocalLoader/index.js
+++ b/src/components/LocalLoader/index.js
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  min-height: 180px;
   width: 100%;
 
   ${(props) =>
@@ -23,7 +23,7 @@ const Wrapper = styled.div`
           height: 100vh;
         `
       : css`
-          height: 180px;
+          height: 100%;
         `}
 `;
 

--- a/src/components/StackedChart/CrosshairTooltip/index.js
+++ b/src/components/StackedChart/CrosshairTooltip/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { formattedNum } from '../../../utils';
 
-const CrosshairTooltip = ({ active, payload }) => {
+const CrosshairTooltip = ({ active, payload, isValueCurrency }) => {
   if (active && payload && payload.length) {
     return (
       <div className="crosshair-custom-tooltip">
@@ -13,7 +13,7 @@ const CrosshairTooltip = ({ active, payload }) => {
               <div className="crosshair-item-legend" style={{ backgroundColor: series.color }}></div>
               {series.name}
             </div>
-            $ {formattedNum(series.value)}
+            {isValueCurrency && '$'} {formattedNum(series.value)}
           </div>
         ))}
       </div>
@@ -26,6 +26,11 @@ const CrosshairTooltip = ({ active, payload }) => {
 CrosshairTooltip.propTypes = {
   active: PropTypes.bool,
   payload: PropTypes.array,
+  isValueCurrency: PropTypes.bool,
+};
+
+CrosshairTooltip.defaultProps = {
+  isValueCurrency: true,
 };
 
 export default CrosshairTooltip;

--- a/src/components/StackedChart/Header/index.js
+++ b/src/components/StackedChart/Header/index.js
@@ -4,19 +4,33 @@ import React from 'react';
 import DropdownSelect from '../../DropdownSelect';
 import { Container, Title, DailyChange, Date, FlexContainer, Value } from './styled';
 
-const Header = ({ title, value, dailyChange, date, filterOptions, activeFilter, onFilterChange }) => (
+const Header = ({
+  title,
+  value,
+  dailyChange,
+  date,
+  filterOptions,
+  activeFilter,
+  onFilterChange,
+  isValueCurrency,
+  showTimeFilter,
+}) => (
   <Container>
     <div>
       <Title>{title}</Title>
       <FlexContainer>
-        <Value>$ {value}</Value>
+        <Value>
+          {isValueCurrency && '$'} {value}
+        </Value>
         <DailyChange>{dailyChange}</DailyChange>
       </FlexContainer>
       <Date>{date}</Date>
     </div>
-    <div>
-      <DropdownSelect active={activeFilter} setActive={onFilterChange} options={filterOptions} width={80} />
-    </div>
+    {showTimeFilter && (
+      <div>
+        <DropdownSelect active={activeFilter} setActive={onFilterChange} options={filterOptions} width={80} />
+      </div>
+    )}
   </Container>
 );
 
@@ -28,6 +42,13 @@ Header.propTypes = {
   filterOptions: PropTypes.object,
   activeFilter: PropTypes.string,
   onFilterChange: PropTypes.func.isRequired,
+  isValueCurrency: PropTypes.bool,
+  showTimeFilter: PropTypes.bool,
+};
+
+Header.defaultProps = {
+  isValueCurrency: true,
+  showTimeFilter: true,
 };
 
 export default Header;

--- a/src/components/StackedChart/index.js
+++ b/src/components/StackedChart/index.js
@@ -139,14 +139,12 @@ const StackedChart = ({ title, type, data }) => {
         filterOptions={TIME_FILTER_OPTIONS}
         onFilterChange={setActiveFilter}
       />
-      <ResponsiveContainer aspect={60 / 28}>
+      <ResponsiveContainer maxHeight={400} maxWith={500} minHeight={300}>
         {type === 'AREA' ? (
           <AreaChart
             className="basic-chart"
             onMouseMove={setCurrentStackedValue}
             onMouseLeave={setDefaultHeaderValues}
-            width={500}
-            height={400}
             data={filteredData}
             margin={{ top: 5 }}
           >
@@ -208,8 +206,6 @@ const StackedChart = ({ title, type, data }) => {
             className="basic-chart"
             onMouseMove={setCurrentStackedValue}
             onMouseLeave={setDefaultHeaderValues}
-            width={500}
-            height={400}
             data={filteredData}
             throttleDelay={15}
             margin={{ top: 5 }}

--- a/src/components/StackedChart/index.js
+++ b/src/components/StackedChart/index.js
@@ -34,21 +34,23 @@ const StackedChart = ({ title, type, data }) => {
 
   // set header values to the latest point of the chart
   const setDefaultHeaderValues = useCallback(() => {
-    let pastStackedDataValue = 0;
-    let currentStackedDataValue = 0;
+    if (data && Object.keys(data).length > 0) {
+      let pastStackedDataValue = 0;
+      let currentStackedDataValue = 0;
 
-    Object.keys(data[data.length - 1])
-      .filter((key) => key !== 'time')
-      .forEach((key) => {
-        currentStackedDataValue += data[data.length - 1][key];
-        pastStackedDataValue += data[data.length - 2][key];
-      });
+      Object.keys(data[data.length - 1])
+        .filter((key) => key !== 'time')
+        .forEach((key) => {
+          currentStackedDataValue += data[data.length - 1][key];
+          pastStackedDataValue += data[data.length - 2][key];
+        });
 
-    const dailyChange = ((currentStackedDataValue - pastStackedDataValue) / pastStackedDataValue) * 100;
+      const dailyChange = ((currentStackedDataValue - pastStackedDataValue) / pastStackedDataValue) * 100;
 
-    setDailyChange(dailyChange);
-    setActiveDate(data[data.length - 1].time);
-    setStackedDataValue(currentStackedDataValue);
+      setDailyChange(dailyChange);
+      setActiveDate(data[data.length - 1].time);
+      setStackedDataValue(currentStackedDataValue);
+    }
   }, [data]);
 
   // set header values to the current point of the chart
@@ -170,6 +172,9 @@ const StackedChart = ({ title, type, data }) => {
               iconType="circle"
               iconSize={10}
               fontSize={14}
+              wrapperStyle={{
+                paddingBottom: 24,
+              }}
               formatter={LegendItem}
             />
             <Tooltip isAnimationActive={false} content={<CrosshairTooltip />} />
@@ -216,6 +221,9 @@ const StackedChart = ({ title, type, data }) => {
               iconType="circle"
               iconSize={10}
               fontSize={14}
+              wrapperStyle={{
+                paddingBottom: 24,
+              }}
               formatter={LegendItem}
             />
             <XAxis dataKey="time" hide />

--- a/src/components/StackedChart/index.js
+++ b/src/components/StackedChart/index.js
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, Bar, ComposedChart, Legend } from 'recharts';
 
 import { TYPE } from '../../Theme';
-import { SupportedNetwork } from '../../constants';
+import { NETWORK_COLORS, SupportedNetwork } from '../../constants';
 import { formattedNum, formattedPercent } from '../../utils';
 import CrosshairTooltip from './CrosshairTooltip';
 import Header from './Header';
@@ -14,18 +14,14 @@ const TIME_FILTER_OPTIONS = {
   MONTH_3: '3M',
   YEAR: '1Y',
 };
-const NETWORK_COLORS = {
-  [SupportedNetwork.MAINNET]: '#2974e0',
-  [SupportedNetwork.XDAI]: '#4526A2',
-  [SupportedNetwork.ARBITRUM_ONE]: '#feb125',
-};
+
 const LegendItem = (value) => (
   <TYPE.light color="text1" as="span">
     {value}
   </TYPE.light>
 );
 
-const StackedChart = ({ title, type, data }) => {
+const StackedChart = ({ title, type, data, maxHeight, maxWith, minHeight }) => {
   const [filteredData, setFilteredData] = useState(data);
   const [stackedDataValue, setStackedDataValue] = useState(null);
   const [activeDate, setActiveDate] = useState(null);
@@ -141,7 +137,7 @@ const StackedChart = ({ title, type, data }) => {
         filterOptions={TIME_FILTER_OPTIONS}
         onFilterChange={setActiveFilter}
       />
-      <ResponsiveContainer maxHeight={400} maxWith={500} minHeight={300}>
+      <ResponsiveContainer maxHeight={maxHeight} maxWith={maxWith} minHeight={minHeight}>
         {type === 'AREA' ? (
           <AreaChart
             className="basic-chart"
@@ -181,19 +177,19 @@ const StackedChart = ({ title, type, data }) => {
             <Area
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.XDAI}
+              dataKey={SupportedNetwork.MAINNET}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
-              fill="url(#xdai)"
+              stroke={NETWORK_COLORS[SupportedNetwork.MAINNET]}
+              fill="url(#mainnet)"
               strokeWidth={3}
             />
             <Area
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.MAINNET}
+              dataKey={SupportedNetwork.XDAI}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.MAINNET]}
-              fill="url(#mainnet)"
+              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
+              fill="url(#xdai)"
               strokeWidth={3}
             />
             <Area
@@ -232,19 +228,19 @@ const StackedChart = ({ title, type, data }) => {
             <Bar
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.XDAI}
+              dataKey={SupportedNetwork.MAINNET}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
-              fill={NETWORK_COLORS[SupportedNetwork.XDAI]}
+              stroke={NETWORK_COLORS[SupportedNetwork.MAINNET]}
+              fill={NETWORK_COLORS[SupportedNetwork.MAINNET]}
               strokeWidth={3}
             />
             <Bar
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.MAINNET}
+              dataKey={SupportedNetwork.XDAI}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.MAINNET]}
-              fill={NETWORK_COLORS[SupportedNetwork.MAINNET]}
+              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
+              fill={NETWORK_COLORS[SupportedNetwork.XDAI]}
               strokeWidth={3}
             />
             <Bar
@@ -266,12 +262,18 @@ const StackedChart = ({ title, type, data }) => {
 StackedChart.propTypes = {
   title: PropTypes.string.isRequired,
   data: PropTypes.any.isRequired,
+  maxHeight: PropTypes.number,
+  maxWith: PropTypes.number,
+  minHeight: PropTypes.number,
   type: PropTypes.oneOf(['BAR', 'AREA']).isRequired,
 };
 
 StackedChart.defaultProps = {
   type: 'AREA',
   data: [],
+  maxHeight: 400,
+  maxWith: 500,
+  minHeight: 300,
 };
 
 export default StackedChart;

--- a/src/components/StackedChart/index.js
+++ b/src/components/StackedChart/index.js
@@ -21,7 +21,7 @@ const LegendItem = (value) => (
   </TYPE.light>
 );
 
-const StackedChart = ({ title, type, data, maxHeight, maxWith, minHeight }) => {
+const StackedChart = ({ title, type, data, isCurrency, showTimeFilter, maxHeight, maxWith, minHeight }) => {
   const [filteredData, setFilteredData] = useState(data);
   const [stackedDataValue, setStackedDataValue] = useState(null);
   const [activeDate, setActiveDate] = useState(null);
@@ -131,6 +131,8 @@ const StackedChart = ({ title, type, data, maxHeight, maxWith, minHeight }) => {
       <Header
         title={title}
         value={formattedNum(stackedDataValue)}
+        isValueCurrency={isCurrency}
+        showTimeFilter={showTimeFilter}
         dailyChange={formattedPercent(dailyChange)}
         date={dayjs(activeDate).format('MMMM D, YYYY')}
         activeFilter={activeFilter}
@@ -173,7 +175,7 @@ const StackedChart = ({ title, type, data, maxHeight, maxWith, minHeight }) => {
               }}
               formatter={LegendItem}
             />
-            <Tooltip isAnimationActive={false} content={<CrosshairTooltip />} />
+            <Tooltip isAnimationActive={false} content={<CrosshairTooltip isValueCurrency={isCurrency} />} />
             <Area
               animationDuration={500}
               type="monotone"
@@ -186,19 +188,19 @@ const StackedChart = ({ title, type, data, maxHeight, maxWith, minHeight }) => {
             <Area
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.XDAI}
+              dataKey={SupportedNetwork.ARBITRUM_ONE}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
-              fill="url(#xdai)"
+              stroke={NETWORK_COLORS[SupportedNetwork.ARBITRUM_ONE]}
+              fill="url(#arbitrum)"
               strokeWidth={3}
             />
             <Area
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.ARBITRUM_ONE}
+              dataKey={SupportedNetwork.XDAI}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.ARBITRUM_ONE]}
-              fill="url(#arbitrum)"
+              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
+              fill="url(#xdai)"
               strokeWidth={3}
             />
           </AreaChart>
@@ -237,19 +239,19 @@ const StackedChart = ({ title, type, data, maxHeight, maxWith, minHeight }) => {
             <Bar
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.XDAI}
+              dataKey={SupportedNetwork.ARBITRUM_ONE}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
-              fill={NETWORK_COLORS[SupportedNetwork.XDAI]}
+              stroke={NETWORK_COLORS[SupportedNetwork.ARBITRUM_ONE]}
+              fill={NETWORK_COLORS[SupportedNetwork.ARBITRUM_ONE]}
               strokeWidth={3}
             />
             <Bar
               animationDuration={500}
               type="monotone"
-              dataKey={SupportedNetwork.ARBITRUM_ONE}
+              dataKey={SupportedNetwork.XDAI}
               stackId="1"
-              stroke={NETWORK_COLORS[SupportedNetwork.ARBITRUM_ONE]}
-              fill={NETWORK_COLORS[SupportedNetwork.ARBITRUM_ONE]}
+              stroke={NETWORK_COLORS[SupportedNetwork.XDAI]}
+              fill={NETWORK_COLORS[SupportedNetwork.XDAI]}
               strokeWidth={3}
             />
           </ComposedChart>
@@ -262,6 +264,8 @@ const StackedChart = ({ title, type, data, maxHeight, maxWith, minHeight }) => {
 StackedChart.propTypes = {
   title: PropTypes.string.isRequired,
   data: PropTypes.any.isRequired,
+  isCurrency: PropTypes.bool,
+  showTimeFilter: PropTypes.bool,
   maxHeight: PropTypes.number,
   maxWith: PropTypes.number,
   minHeight: PropTypes.number,
@@ -271,6 +275,8 @@ StackedChart.propTypes = {
 StackedChart.defaultProps = {
   type: 'AREA',
   data: [],
+  isCurrency: true,
+  showTimeFilter: true,
   maxHeight: 400,
   maxWith: 500,
   minHeight: 300,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -117,3 +117,9 @@ export const BLOCK_DIFFERENCE_THRESHOLD = {
   [SupportedNetwork.XDAI]: DEFAULT_BLOCK_DIFFERENCE_THRESHOLD,
   [SupportedNetwork.ARBITRUM_ONE]: 200, // Arbitrum one has multiple blocks in the same second
 };
+
+export const NETWORK_COLORS = {
+  [SupportedNetwork.MAINNET]: '#2974e0',
+  [SupportedNetwork.XDAI]: '#4526A2',
+  [SupportedNetwork.ARBITRUM_ONE]: '#feb125',
+};

--- a/src/contexts/Dashboard.js
+++ b/src/contexts/Dashboard.js
@@ -192,7 +192,7 @@ export const useTransactionsData = () => {
 };
 
 /**
- * Get historical data for transaction for each network (last 3 months)
+ * Get historical data for transactions for each network (last 1 month)
  */
 const getTransactions = async () => {
   try {

--- a/src/contexts/Dashboard.js
+++ b/src/contexts/Dashboard.js
@@ -51,9 +51,7 @@ function reducer(state, { type, payload }) {
       const { comulativeNetworksData } = payload;
       return {
         ...state,
-        comulativeData: {
-          ...comulativeNetworksData,
-        },
+        comulativeData: comulativeNetworksData,
       };
     }
 
@@ -199,7 +197,7 @@ const getTransactions = async () => {
     let transactions = [];
 
     const utcCurrentTime = dayjs();
-    const utcThreeMonthsBack = utcCurrentTime.subtract(1, 'month').startOf('minute').unix();
+    const utcOneMonthBack = utcCurrentTime.subtract(1, 'month').startOf('minute').unix();
 
     for (const { client, network } of SUPPORTED_CLIENTS) {
       let lastId = '';
@@ -209,7 +207,7 @@ const getTransactions = async () => {
         const { data } = await client.query({
           query: DASHBOARD_TRANSACTION_HISTORY,
           variables: {
-            startTime: utcThreeMonthsBack,
+            startTime: utcOneMonthBack,
             lastId,
           },
         });

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -38,12 +38,6 @@ const GridCard = styled.div`
   row-gap: 16px;
 `;
 
-const GridCardRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  column-gap: 16px;
-`;
-
 const PanelLoaderWrapper = ({ isLoading, children }) => <Panel>{isLoading ? <LocalLoader /> : children}</Panel>;
 
 const DashboardPage = () => {

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -14,7 +14,7 @@ import LocalLoader from '../components/LocalLoader';
 import Panel from '../components/Panel';
 import StackedChart from '../components/StackedChart';
 import { SupportedNetwork } from '../constants';
-import { useDashboardChartData, useDashboardComulativeData, useTransactionsData } from '../contexts/Dashboard';
+import { useDashboardChartData, useDashboardComulativeData } from '../contexts/Dashboard';
 import { formattedNum } from '../utils';
 
 const GridRow = styled.div`
@@ -49,7 +49,6 @@ const PanelLoaderWrapper = ({ isLoading, children }) => <Panel>{isLoading ? <Loc
 const DashboardPage = () => {
   const chartData = useDashboardChartData();
   const comulativeData = useDashboardComulativeData();
-  const transactions = useTransactionsData();
   const [formattedLiquidityData, setFormattedLiquidityData] = useState([]);
   const [formattedVolumeData, setFormattedVolumeData] = useState([]);
   const [formattedTotalTrades, setFormattedTotalTrades] = useState([]);
@@ -121,7 +120,6 @@ const DashboardPage = () => {
   const isVolumeAndTvlLoading = chartData === undefined || Object.keys(chartData).length === 0;
   const isAllTimeVolumeLoading = formattedTotalVolume.length === 0;
   const isTotalTradesLoading = formattedTotalTrades.length === 0;
-  const isTransactionsLoading = !transactions || transactions.length === 0;
 
   return (
     <PageWrapper>
@@ -154,15 +152,6 @@ const DashboardPage = () => {
                     networksValues={formattedTotalTrades}
                   />
                 </PanelLoaderWrapper>
-                <PanelLoaderWrapper isLoading={isTransactionsLoading}>
-                  <StackedChart
-                    title={'Transactions'}
-                    type={'AREA'}
-                    data={transactions}
-                    isCurrency={false}
-                    showTimeFilter={false}
-                  />
-                </PanelLoaderWrapper>
               </AutoColumn>
             ) : below1400 ? (
               <AutoColumn style={{ marginTop: '6px' }} gap={'16px'}>
@@ -172,35 +161,24 @@ const DashboardPage = () => {
                 <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
                   <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
                 </PanelLoaderWrapper>
-                <GridCardRow>
-                  <AutoColumn gap={'16px'}>
-                    <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
-                      <ComulativeNetworkDataCard
-                        title={'All time volume'}
-                        icon={<DollarSign size={22} color={'#50dfb6'} />}
-                        comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                        networksValues={formattedTotalVolume}
-                      />
-                    </PanelLoaderWrapper>
-                    <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
-                      <ComulativeNetworkDataCard
-                        title={'Total trades'}
-                        icon={<FileText size={22} color={'#50dfb6'} />}
-                        comulativeValue={formattedNum(comulativeData.totalTrades)}
-                        networksValues={formattedTotalTrades}
-                      />
-                    </PanelLoaderWrapper>
-                  </AutoColumn>
-                  <PanelLoaderWrapper isLoading={isTransactionsLoading}>
-                    <StackedChart
-                      title={'Transactions'}
-                      type={'AREA'}
-                      data={transactions}
-                      isCurrency={false}
-                      showTimeFilter={false}
+                <AutoColumn gap={'16px'}>
+                  <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
+                    <ComulativeNetworkDataCard
+                      title={'All time volume'}
+                      icon={<DollarSign size={22} color={'#50dfb6'} />}
+                      comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                      networksValues={formattedTotalVolume}
                     />
                   </PanelLoaderWrapper>
-                </GridCardRow>
+                  <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
+                    <ComulativeNetworkDataCard
+                      title={'Total trades'}
+                      icon={<FileText size={22} color={'#50dfb6'} />}
+                      comulativeValue={formattedNum(comulativeData.totalTrades)}
+                      networksValues={formattedTotalTrades}
+                    />
+                  </PanelLoaderWrapper>
+                </AutoColumn>
               </AutoColumn>
             ) : (
               <GridRow>
@@ -228,15 +206,6 @@ const DashboardPage = () => {
                         icon={<FileText size={22} color={'#50dfb6'} />}
                         comulativeValue={formattedNum(comulativeData.totalTrades)}
                         networksValues={formattedTotalTrades}
-                      />
-                    </PanelLoaderWrapper>
-                    <PanelLoaderWrapper isLoading={isTransactionsLoading}>
-                      <StackedChart
-                        title={'Transactions'}
-                        type={'AREA'}
-                        data={transactions}
-                        isCurrency={false}
-                        showTimeFilter={false}
                       />
                     </PanelLoaderWrapper>
                   </GridCard>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -14,7 +14,7 @@ import LocalLoader from '../components/LocalLoader';
 import Panel from '../components/Panel';
 import StackedChart from '../components/StackedChart';
 import { SupportedNetwork } from '../constants';
-import { useDashboardChartData, useDashboardComulativeData } from '../contexts/Dashboard';
+import { useDashboardChartData, useDashboardComulativeData, useTransactionsData } from '../contexts/Dashboard';
 import { formattedNum } from '../utils';
 
 const GridRow = styled.div`
@@ -44,9 +44,12 @@ const GridCardRow = styled.div`
   column-gap: 16px;
 `;
 
+const PanelLoaderWrapper = ({ isLoading, children }) => <Panel>{isLoading ? <LocalLoader /> : children}</Panel>;
+
 const DashboardPage = () => {
   const chartData = useDashboardChartData();
   const comulativeData = useDashboardComulativeData();
+  const transactions = useTransactionsData();
   const [formattedLiquidityData, setFormattedLiquidityData] = useState([]);
   const [formattedVolumeData, setFormattedVolumeData] = useState([]);
   const [formattedTotalTrades, setFormattedTotalTrades] = useState([]);
@@ -115,14 +118,10 @@ const DashboardPage = () => {
     });
   }, []);
 
-  if (
-    chartData === undefined ||
-    Object.keys(chartData).length === 0 ||
-    comulativeData === undefined ||
-    Object.keys(comulativeData).length === 0
-  ) {
-    return <LocalLoader fill="true" />;
-  }
+  const isVolumeAndTvlLoading = chartData === undefined || Object.keys(chartData).length === 0;
+  const isAllTimeVolumeLoading = formattedTotalVolume.length === 0;
+  const isTotalTradesLoading = formattedTotalTrades.length === 0;
+  const isTransactionsLoading = !transactions || transactions.length === 0;
 
   return (
     <PageWrapper>
@@ -132,75 +131,114 @@ const DashboardPage = () => {
         {formattedLiquidityData && (
           <>
             {below800 ? (
-              <AutoColumn style={{ marginTop: '6px' }} gap="16px">
-                <Panel style={{ height: '100%' }}>
+              <AutoColumn style={{ marginTop: '6px' }} gap={'16px'}>
+                <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
                   <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
-                </Panel>
-                <Panel style={{ height: '100%' }}>
+                </PanelLoaderWrapper>
+                <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
                   <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
-                </Panel>
-                <ComulativeNetworkDataCard
-                  title={'All time volume'}
-                  icon={<DollarSign size={22} color="#50dfb6" />}
-                  comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                  networksValues={formattedTotalVolume}
-                />
-                <ComulativeNetworkDataCard
-                  title={'Total trades'}
-                  icon={<FileText size={22} color="#50dfb6" />}
-                  comulativeValue={formattedNum(comulativeData.totalTrades)}
-                  networksValues={formattedTotalTrades}
-                />
-              </AutoColumn>
-            ) : below1400 ? (
-              <AutoColumn style={{ marginTop: '6px' }} gap="16px">
-                <Panel style={{ height: '100%' }}>
-                  <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
-                </Panel>
-                <Panel style={{ height: '100%' }}>
-                  <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
-                </Panel>
-                <GridCardRow>
+                </PanelLoaderWrapper>
+                <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
                   <ComulativeNetworkDataCard
                     title={'All time volume'}
-                    icon={<DollarSign size={22} color="#50dfb6" />}
+                    icon={<DollarSign size={22} color={'#50dfb6'} />}
                     comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
                     networksValues={formattedTotalVolume}
                   />
+                </PanelLoaderWrapper>
+                <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
                   <ComulativeNetworkDataCard
                     title={'Total trades'}
-                    icon={<FileText size={22} color="#50dfb6" />}
+                    icon={<FileText size={22} color={'#50dfb6'} />}
                     comulativeValue={formattedNum(comulativeData.totalTrades)}
                     networksValues={formattedTotalTrades}
                   />
+                </PanelLoaderWrapper>
+                <PanelLoaderWrapper isLoading={isTransactionsLoading}>
+                  <StackedChart
+                    title={'Transactions'}
+                    type={'AREA'}
+                    data={transactions}
+                    isCurrency={false}
+                    showTimeFilter={false}
+                  />
+                </PanelLoaderWrapper>
+              </AutoColumn>
+            ) : below1400 ? (
+              <AutoColumn style={{ marginTop: '6px' }} gap={'16px'}>
+                <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
+                  <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
+                </PanelLoaderWrapper>
+                <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
+                  <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
+                </PanelLoaderWrapper>
+                <GridCardRow>
+                  <AutoColumn gap={'16px'}>
+                    <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
+                      <ComulativeNetworkDataCard
+                        title={'All time volume'}
+                        icon={<DollarSign size={22} color={'#50dfb6'} />}
+                        comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                        networksValues={formattedTotalVolume}
+                      />
+                    </PanelLoaderWrapper>
+                    <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
+                      <ComulativeNetworkDataCard
+                        title={'Total trades'}
+                        icon={<FileText size={22} color={'#50dfb6'} />}
+                        comulativeValue={formattedNum(comulativeData.totalTrades)}
+                        networksValues={formattedTotalTrades}
+                      />
+                    </PanelLoaderWrapper>
+                  </AutoColumn>
+                  <PanelLoaderWrapper isLoading={isTransactionsLoading}>
+                    <StackedChart
+                      title={'Transactions'}
+                      type={'AREA'}
+                      data={transactions}
+                      isCurrency={false}
+                      showTimeFilter={false}
+                    />
+                  </PanelLoaderWrapper>
                 </GridCardRow>
               </AutoColumn>
             ) : (
               <GridRow>
-                <div>
-                  <GridChart>
-                    <Panel style={{ height: '100%' }}>
-                      <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
-                    </Panel>
-                    <Panel style={{ height: '100%' }}>
-                      <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
-                    </Panel>
-                  </GridChart>
-                </div>
+                <GridChart>
+                  <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
+                    <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
+                  </PanelLoaderWrapper>
+                  <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
+                    <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
+                  </PanelLoaderWrapper>
+                </GridChart>
                 <div>
                   <GridCard>
-                    <ComulativeNetworkDataCard
-                      title={'All time volume'}
-                      icon={<DollarSign size={22} color="#50dfb6" />}
-                      comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                      networksValues={formattedTotalVolume}
-                    />
-                    <ComulativeNetworkDataCard
-                      title={'Total trades'}
-                      icon={<FileText size={22} color="#50dfb6" />}
-                      comulativeValue={formattedNum(comulativeData.totalTrades)}
-                      networksValues={formattedTotalTrades}
-                    />
+                    <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
+                      <ComulativeNetworkDataCard
+                        title={'All time volume'}
+                        icon={<DollarSign size={22} color={'#50dfb6'} />}
+                        comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                        networksValues={formattedTotalVolume}
+                      />
+                    </PanelLoaderWrapper>
+                    <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
+                      <ComulativeNetworkDataCard
+                        title={'Total trades'}
+                        icon={<FileText size={22} color={'#50dfb6'} />}
+                        comulativeValue={formattedNum(comulativeData.totalTrades)}
+                        networksValues={formattedTotalTrades}
+                      />
+                    </PanelLoaderWrapper>
+                    <PanelLoaderWrapper isLoading={isTransactionsLoading}>
+                      <StackedChart
+                        title={'Transactions'}
+                        type={'AREA'}
+                        data={transactions}
+                        isCurrency={false}
+                        showTimeFilter={false}
+                      />
+                    </PanelLoaderWrapper>
                   </GridCard>
                 </div>
               </GridRow>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { transparentize } from 'polished';
 import React, { useEffect, useState } from 'react';
+import { DollarSign, FileText } from 'react-feather';
 import { withRouter } from 'react-router-dom';
 import { useMedia } from 'react-use';
 import styled from 'styled-components';
@@ -8,30 +9,49 @@ import styled from 'styled-components';
 import { TYPE, ThemedBackground } from '../Theme';
 import { PageWrapper, ContentWrapper } from '../components';
 import { AutoColumn } from '../components/Column';
+import ComulativeNetworkDataCard from '../components/ComulativeNetworkDataCard';
 import LocalLoader from '../components/LocalLoader';
 import Panel from '../components/Panel';
 import StackedChart from '../components/StackedChart';
-import { useDashboardChartData } from '../contexts/Dashboard';
+import { SupportedNetwork } from '../constants';
+import { useDashboardChartData, useDashboardComulativeData } from '../contexts/Dashboard';
+import { formattedNum } from '../utils';
 
 const GridRow = styled.div`
   display: grid;
-  width: 100%;
-  grid-template-columns: 1fr 1fr;
-  column-gap: 6px;
-  align-items: start;
-  justify-content: space-between;
+  grid-template-columns: 3fr 1.5fr;
+  column-gap: 16px;
+  row-gap: 16px;
+`;
+
+const GridChart = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 416px 416px;
+  row-gap: 16px;
+`;
+
+const GridCard = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
+  row-gap: 16px;
 `;
 
 const DashboardPage = () => {
   const chartData = useDashboardChartData();
+  const comulativeData = useDashboardComulativeData();
   const [formattedLiquidityData, setFormattedLiquidityData] = useState([]);
   const [formattedVolumeData, setFormattedVolumeData] = useState([]);
+  const [formattedTotalTrades, setFormattedTotalTrades] = useState([]);
+  const [formattedTotalVolume, setFormattedTotalVolume] = useState([]);
 
   // breakpoints
   const below800 = useMedia('(max-width: 800px)');
 
   useEffect(() => {
     if (chartData && chartData.daily) {
+      // group daily volume and liquidity data by date
       const formattedData = Object.values(
         chartData.daily.reduce(
           (accumulator, current) => ({
@@ -52,12 +72,34 @@ const DashboardPage = () => {
         ),
       );
 
-      // group daily liquidity data by date
       setFormattedLiquidityData(formattedData.map(({ time, tvl }) => ({ time, ...tvl })));
-      // group daily volume data by date
       setFormattedVolumeData(formattedData.map(({ time, volume }) => ({ time, ...volume })));
     }
   }, [chartData]);
+
+  useEffect(() => {
+    if (comulativeData && Object.keys(comulativeData).length > 0) {
+      const totalTradesPerNetwork = [];
+      const totalVolumePerNetwork = [];
+
+      Object.keys(comulativeData)
+        // include only network specific data
+        .filter((key) => Object.values(SupportedNetwork).includes(key))
+        .forEach((network) => {
+          totalTradesPerNetwork.push({
+            network,
+            value: formattedNum(comulativeData[network].totalTrades),
+          });
+          totalVolumePerNetwork.push({
+            network,
+            value: `$ ${formattedNum(comulativeData[network].totalVolume)}`,
+          });
+        });
+
+      setFormattedTotalTrades(totalTradesPerNetwork);
+      setFormattedTotalVolume(totalVolumePerNetwork);
+    }
+  }, [comulativeData]);
 
   useEffect(() => {
     window.scrollTo({
@@ -68,7 +110,10 @@ const DashboardPage = () => {
 
   return (
     <>
-      {(chartData === undefined || Object.keys(chartData).length === 0) && <LocalLoader fill="true" />}
+      {(chartData === undefined ||
+        Object.keys(chartData).length === 0 ||
+        comulativeData === undefined ||
+        Object.keys(comulativeData).length === 0) && <LocalLoader fill="true" />}
       <PageWrapper>
         <ThemedBackground backgroundColor={transparentize(0.8, '#4526A2')} />
         <ContentWrapper>
@@ -83,15 +128,47 @@ const DashboardPage = () => {
                   <Panel style={{ height: '100%' }}>
                     <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
                   </Panel>
+                  <ComulativeNetworkDataCard
+                    title={'All time volume'}
+                    icon={<DollarSign size={22} color="#50dfb6" />}
+                    comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                    networksValues={formattedTotalVolume}
+                  />
+                  <ComulativeNetworkDataCard
+                    title={'Total trades'}
+                    icon={<FileText size={22} color="#50dfb6" />}
+                    comulativeValue={formattedNum(comulativeData.totalTrades)}
+                    networksValues={formattedTotalTrades}
+                  />
                 </AutoColumn>
               ) : (
                 <GridRow>
-                  <Panel style={{ height: '100%' }}>
-                    <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
-                  </Panel>
-                  <Panel style={{ height: '100%' }}>
-                    <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
-                  </Panel>
+                  <div>
+                    <GridChart>
+                      <Panel style={{ height: '100%' }}>
+                        <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
+                      </Panel>
+                      <Panel style={{ height: '100%' }}>
+                        <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
+                      </Panel>
+                    </GridChart>
+                  </div>
+                  <div>
+                    <GridCard>
+                      <ComulativeNetworkDataCard
+                        title={'All time volume'}
+                        icon={<DollarSign size={22} color="#50dfb6" />}
+                        comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                        networksValues={formattedTotalVolume}
+                      />
+                      <ComulativeNetworkDataCard
+                        title={'Total trades'}
+                        icon={<FileText size={22} color="#50dfb6" />}
+                        comulativeValue={formattedNum(comulativeData.totalTrades)}
+                        networksValues={formattedTotalTrades}
+                      />
+                    </GridCard>
+                  </div>
                 </GridRow>
               )}
             </>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -38,6 +38,12 @@ const GridCard = styled.div`
   row-gap: 16px;
 `;
 
+const GridCardRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 16px;
+`;
+
 const DashboardPage = () => {
   const chartData = useDashboardChartData();
   const comulativeData = useDashboardComulativeData();
@@ -48,6 +54,7 @@ const DashboardPage = () => {
 
   // breakpoints
   const below800 = useMedia('(max-width: 800px)');
+  const below1400 = useMedia('(max-width: 1400px)');
 
   useEffect(() => {
     if (chartData && chartData.daily) {
@@ -125,7 +132,7 @@ const DashboardPage = () => {
         {formattedLiquidityData && (
           <>
             {below800 ? (
-              <AutoColumn style={{ marginTop: '6px' }} gap="24px">
+              <AutoColumn style={{ marginTop: '6px' }} gap="16px">
                 <Panel style={{ height: '100%' }}>
                   <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
                 </Panel>
@@ -144,6 +151,29 @@ const DashboardPage = () => {
                   comulativeValue={formattedNum(comulativeData.totalTrades)}
                   networksValues={formattedTotalTrades}
                 />
+              </AutoColumn>
+            ) : below1400 ? (
+              <AutoColumn style={{ marginTop: '6px' }} gap="16px">
+                <Panel style={{ height: '100%' }}>
+                  <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
+                </Panel>
+                <Panel style={{ height: '100%' }}>
+                  <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
+                </Panel>
+                <GridCardRow>
+                  <ComulativeNetworkDataCard
+                    title={'All time volume'}
+                    icon={<DollarSign size={22} color="#50dfb6" />}
+                    comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                    networksValues={formattedTotalVolume}
+                  />
+                  <ComulativeNetworkDataCard
+                    title={'Total trades'}
+                    icon={<FileText size={22} color="#50dfb6" />}
+                    comulativeValue={formattedNum(comulativeData.totalTrades)}
+                    networksValues={formattedTotalTrades}
+                  />
+                </GridCardRow>
               </AutoColumn>
             ) : (
               <GridRow>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -45,8 +45,7 @@ const DashboardPage = () => {
   const comulativeData = useDashboardComulativeData();
   const [formattedLiquidityData, setFormattedLiquidityData] = useState([]);
   const [formattedVolumeData, setFormattedVolumeData] = useState([]);
-  const [formattedTotalTrades, setFormattedTotalTrades] = useState([]);
-  const [formattedTotalVolume, setFormattedTotalVolume] = useState([]);
+  const [formattedComulativeData, setFormattedComulativeData] = useState({ trades: [], volume: [] });
 
   // breakpoints
   const below800 = useMedia('(max-width: 800px)');
@@ -99,8 +98,7 @@ const DashboardPage = () => {
           });
         });
 
-      setFormattedTotalTrades(totalTradesPerNetwork);
-      setFormattedTotalVolume(totalVolumePerNetwork);
+      setFormattedComulativeData({ trades: totalTradesPerNetwork, volume: totalVolumePerNetwork });
     }
   }, [comulativeData]);
 
@@ -112,8 +110,8 @@ const DashboardPage = () => {
   }, []);
 
   const isVolumeAndTvlLoading = chartData === undefined || Object.keys(chartData).length === 0;
-  const isAllTimeVolumeLoading = formattedTotalVolume.length === 0;
-  const isTotalTradesLoading = formattedTotalTrades.length === 0;
+  const isComulativeDataLoading =
+    formattedComulativeData.trades.length === 0 || formattedComulativeData.volume.length === 0;
 
   return (
     <PageWrapper>
@@ -130,20 +128,20 @@ const DashboardPage = () => {
                 <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
                   <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
                 </PanelLoaderWrapper>
-                <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
+                <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
                   <ComulativeNetworkDataCard
                     title={'All time volume'}
                     icon={<DollarSign size={22} color={'#50dfb6'} />}
                     comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                    networksValues={formattedTotalVolume}
+                    networksValues={formattedComulativeData.volume}
                   />
                 </PanelLoaderWrapper>
-                <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
+                <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
                   <ComulativeNetworkDataCard
                     title={'Total trades'}
                     icon={<FileText size={22} color={'#50dfb6'} />}
                     comulativeValue={formattedNum(comulativeData.totalTrades)}
-                    networksValues={formattedTotalTrades}
+                    networksValues={formattedComulativeData.trades}
                   />
                 </PanelLoaderWrapper>
               </AutoColumn>
@@ -156,20 +154,20 @@ const DashboardPage = () => {
                   <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
                 </PanelLoaderWrapper>
                 <AutoColumn gap={'16px'}>
-                  <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
+                  <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
                     <ComulativeNetworkDataCard
                       title={'All time volume'}
                       icon={<DollarSign size={22} color={'#50dfb6'} />}
                       comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                      networksValues={formattedTotalVolume}
+                      networksValues={formattedComulativeData.volume}
                     />
                   </PanelLoaderWrapper>
-                  <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
+                  <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
                     <ComulativeNetworkDataCard
                       title={'Total trades'}
                       icon={<FileText size={22} color={'#50dfb6'} />}
                       comulativeValue={formattedNum(comulativeData.totalTrades)}
-                      networksValues={formattedTotalTrades}
+                      networksValues={formattedComulativeData.trades}
                     />
                   </PanelLoaderWrapper>
                 </AutoColumn>
@@ -186,20 +184,20 @@ const DashboardPage = () => {
                 </GridChart>
                 <div>
                   <GridCard>
-                    <PanelLoaderWrapper isLoading={isAllTimeVolumeLoading}>
+                    <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
                       <ComulativeNetworkDataCard
                         title={'All time volume'}
                         icon={<DollarSign size={22} color={'#50dfb6'} />}
                         comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                        networksValues={formattedTotalVolume}
+                        networksValues={formattedComulativeData.volume}
                       />
                     </PanelLoaderWrapper>
-                    <PanelLoaderWrapper isLoading={isTotalTradesLoading}>
+                    <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
                       <ComulativeNetworkDataCard
                         title={'Total trades'}
                         icon={<FileText size={22} color={'#50dfb6'} />}
                         comulativeValue={formattedNum(comulativeData.totalTrades)}
-                        networksValues={formattedTotalTrades}
+                        networksValues={formattedComulativeData.trades}
                       />
                     </PanelLoaderWrapper>
                   </GridCard>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -108,75 +108,77 @@ const DashboardPage = () => {
     });
   }, []);
 
+  if (
+    chartData === undefined ||
+    Object.keys(chartData).length === 0 ||
+    comulativeData === undefined ||
+    Object.keys(comulativeData).length === 0
+  ) {
+    return <LocalLoader fill="true" />;
+  }
+
   return (
-    <>
-      {(chartData === undefined ||
-        Object.keys(chartData).length === 0 ||
-        comulativeData === undefined ||
-        Object.keys(comulativeData).length === 0) && <LocalLoader fill="true" />}
-      <PageWrapper>
-        <ThemedBackground backgroundColor={transparentize(0.8, '#4526A2')} />
-        <ContentWrapper>
-          <TYPE.largeHeader>{below800 ? 'Analytics Dashboard' : 'Swapr Protocol Analytics Dashboard'}</TYPE.largeHeader>
-          {formattedLiquidityData && (
-            <>
-              {below800 ? (
-                <AutoColumn style={{ marginTop: '6px' }} gap="24px">
-                  <Panel style={{ height: '100%' }}>
-                    <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
-                  </Panel>
-                  <Panel style={{ height: '100%' }}>
-                    <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
-                  </Panel>
-                  <ComulativeNetworkDataCard
-                    title={'All time volume'}
-                    icon={<DollarSign size={22} color="#50dfb6" />}
-                    comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                    networksValues={formattedTotalVolume}
-                  />
-                  <ComulativeNetworkDataCard
-                    title={'Total trades'}
-                    icon={<FileText size={22} color="#50dfb6" />}
-                    comulativeValue={formattedNum(comulativeData.totalTrades)}
-                    networksValues={formattedTotalTrades}
-                  />
-                </AutoColumn>
-              ) : (
-                <GridRow>
-                  <div>
-                    <GridChart>
-                      <Panel style={{ height: '100%' }}>
-                        <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
-                      </Panel>
-                      <Panel style={{ height: '100%' }}>
-                        <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
-                      </Panel>
-                    </GridChart>
-                  </div>
-                  <div>
-                    <GridCard>
-                      <ComulativeNetworkDataCard
-                        title={'All time volume'}
-                        icon={<DollarSign size={22} color="#50dfb6" />}
-                        comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
-                        networksValues={formattedTotalVolume}
-                      />
-                      <ComulativeNetworkDataCard
-                        title={'Total trades'}
-                        icon={<FileText size={22} color="#50dfb6" />}
-                        comulativeValue={formattedNum(comulativeData.totalTrades)}
-                        networksValues={formattedTotalTrades}
-                      />
-                    </GridCard>
-                  </div>
-                </GridRow>
-              )}
-            </>
-          )}
-        </ContentWrapper>
-        )
-      </PageWrapper>
-    </>
+    <PageWrapper>
+      <ThemedBackground backgroundColor={transparentize(0.8, '#4526A2')} />
+      <ContentWrapper>
+        <TYPE.largeHeader>{below800 ? 'Analytics Dashboard' : 'Swapr Protocol Analytics Dashboard'}</TYPE.largeHeader>
+        {formattedLiquidityData && (
+          <>
+            {below800 ? (
+              <AutoColumn style={{ marginTop: '6px' }} gap="24px">
+                <Panel style={{ height: '100%' }}>
+                  <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
+                </Panel>
+                <Panel style={{ height: '100%' }}>
+                  <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
+                </Panel>
+                <ComulativeNetworkDataCard
+                  title={'All time volume'}
+                  icon={<DollarSign size={22} color="#50dfb6" />}
+                  comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                  networksValues={formattedTotalVolume}
+                />
+                <ComulativeNetworkDataCard
+                  title={'Total trades'}
+                  icon={<FileText size={22} color="#50dfb6" />}
+                  comulativeValue={formattedNum(comulativeData.totalTrades)}
+                  networksValues={formattedTotalTrades}
+                />
+              </AutoColumn>
+            ) : (
+              <GridRow>
+                <div>
+                  <GridChart>
+                    <Panel style={{ height: '100%' }}>
+                      <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />
+                    </Panel>
+                    <Panel style={{ height: '100%' }}>
+                      <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
+                    </Panel>
+                  </GridChart>
+                </div>
+                <div>
+                  <GridCard>
+                    <ComulativeNetworkDataCard
+                      title={'All time volume'}
+                      icon={<DollarSign size={22} color="#50dfb6" />}
+                      comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
+                      networksValues={formattedTotalVolume}
+                    />
+                    <ComulativeNetworkDataCard
+                      title={'Total trades'}
+                      icon={<FileText size={22} color="#50dfb6" />}
+                      comulativeValue={formattedNum(comulativeData.totalTrades)}
+                      networksValues={formattedTotalTrades}
+                    />
+                  </GridCard>
+                </div>
+              </GridRow>
+            )}
+          </>
+        )}
+      </ContentWrapper>
+    </PageWrapper>
   );
 };
 


### PR DESCRIPTION
# Summary

Relative to #41 

Done:
- Bit of layout change to the dashboard page
- Load each component in the dashboard separately
- Add cumulative `Volume` data card
- Add cumulative `Trades` data card

![image](https://user-images.githubusercontent.com/9011637/165386233-a02aad8d-60c3-4054-b46b-dcb7f4326fd7.png)

![image](https://user-images.githubusercontent.com/9011637/165385438-238b72f7-e9b1-4e7d-9c75-5e14e44e046d.png)

# How To Test
1.  Open the page `Dashboard`
- [ ] Verify that `All time volume` and `Transactions` data card exist.

# Background 

There are also changes that include the transactions historical data, that are not required for the cumulative data cards but are needed for the new transactions card (WIP)