### PR TITLE
feat: add wallets data card to dashboard

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -461,6 +461,35 @@ export const DASHBOARD_SWAPS_HISTORY = gql`
   }
 `;
 
+export const DASHBOARD_MINTS_AND_SWAPS_TRANSACTIONS_WITH_TIMESTAMP = gql`
+  query transactions($lastId: ID!, $startTime: Int!) {
+    transactions(first: 1000, where: { id_gt: $lastId, timestamp_gt: $startTime }) {
+      id
+      timestamp
+      mints {
+        to
+      }
+      swaps {
+        to
+      }
+    }
+  }
+`;
+
+export const DASHBOARD_MINTS_AND_SWAPS_TRANSACTIONS = gql`
+  query transactions($lastId: ID!, $startTime: Int!) {
+    transactions(first: 1000, where: { id_gt: $lastId, timestamp_gt: $startTime }) {
+      id
+      mints {
+        to
+      }
+      swaps {
+        to
+      }
+    }
+  }
+`;
+
 export const DASHBOARD_CHART = gql`
   query swaprDayDatas($startTime: Int!, $skip: Int!) {
     swaprDayDatas(first: 365, skip: $skip, where: { date_gt: $startTime }, orderBy: date, orderDirection: asc) {

--- a/src/components/ComulativeNetworkDataCard/index.js
+++ b/src/components/ComulativeNetworkDataCard/index.js
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { TYPE } from '../../Theme';
-import { Header, Value, Content, Network, NetworkData, Title, Icon } from './styled';
+import { Wrapper, Header, Value, Content, Network, NetworkData, Title, Icon } from './styled';
 
 const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
-  <>
+  <Wrapper>
     <Header>
       <Title>
         <Icon>{icon}</Icon>
@@ -21,7 +21,7 @@ const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
         </NetworkData>
       ))}
     </Content>
-  </>
+  </Wrapper>
 );
 
 DataCard.propTypes = {

--- a/src/components/ComulativeNetworkDataCard/styled.js
+++ b/src/components/ComulativeNetworkDataCard/styled.js
@@ -1,10 +1,8 @@
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  height: 163px;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
 `;
 
 const Header = styled.div`
@@ -39,8 +37,6 @@ const Content = styled.div`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  padding-left: 10%;
-  padding-right: 10%;
 `;
 
 const NetworkData = styled.div`

--- a/src/components/ComulativeNetworkDataCard/styled.js
+++ b/src/components/ComulativeNetworkDataCard/styled.js
@@ -1,5 +1,12 @@
 import styled from 'styled-components';
 
+const Wrapper = styled.div`
+  height: 163px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
+
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
@@ -32,6 +39,8 @@ const Content = styled.div`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+  padding-left: 10%;
+  padding-right: 10%;
 `;
 
 const NetworkData = styled.div`
@@ -39,4 +48,4 @@ const NetworkData = styled.div`
   margin-right: 36px;
 `;
 
-export { Header, Title, Icon, Value, Network, Content, NetworkData };
+export { Wrapper, Header, Title, Icon, Value, Network, Content, NetworkData };

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Wrapper } from './styled';
+
+interface IconProps {
+  icon: React.ReactElement;
+  color: string;
+  size: number;
+}
+
+const Icon = ({ icon, color, size = 22 }: IconProps) => (
+  <Wrapper color={color}>{React.cloneElement(icon, { size })}</Wrapper>
+);
+
+export default Icon;

--- a/src/components/Icon/styled.tsx
+++ b/src/components/Icon/styled.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div<{ theme: any; color: string }>`
+  color: ${({ theme, color }) => (color ? theme[color] : theme.green1)};
+`;

--- a/src/components/LocalLoader/index.js
+++ b/src/components/LocalLoader/index.js
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 180px;
+  min-height: ${({ height }) => (height ? height : '180px')};
   width: 100%;
 
   ${(props) =>
@@ -34,11 +34,11 @@ const AnimatedImg = styled.div`
   }
 `;
 
-const LocalLoader = ({ fill }) => {
+const LocalLoader = ({ fill, height }) => {
   const [darkMode] = useDarkModeManager();
 
   return (
-    <Wrapper fill={fill}>
+    <Wrapper fill={fill} height={height}>
       <AnimatedImg>
         <img
           src={require(darkMode ? '../../assets/svg/logo_white.svg' : '../../assets/svg/logo.svg')}

--- a/src/components/NetworkDataCardWithDialog/Dialog/index.tsx
+++ b/src/components/NetworkDataCardWithDialog/Dialog/index.tsx
@@ -1,7 +1,6 @@
 import { useTransition, config, animated } from '@react-spring/web';
 import React from 'react';
 
-import { useSwapsData } from '../../../contexts/Dashboard';
 import LocalLoader from '../../LocalLoader';
 import StackedChart from '../../StackedChart';
 import { CloseChartIcon, StyledDialogContent, StyledDialogOverlay, Wrapper } from './styled';
@@ -10,12 +9,14 @@ const AnimatedDialogOverlay = animated(StyledDialogOverlay);
 const AnimatedDialogContent = animated(StyledDialogContent);
 
 interface DialogWithChartProps {
+  title: string;
+  historicalDataHook: any;
   isOpen: boolean;
   onClose: React.MouseEventHandler;
 }
 
-const DialogWithChart = ({ isOpen, onClose }: DialogWithChartProps) => {
-  const swaps = useSwapsData();
+const DialogWithChart = ({ title, historicalDataHook, isOpen, onClose }: DialogWithChartProps) => {
+  const data = historicalDataHook();
 
   const transitions = useTransition(isOpen, {
     config: { ...config.default, duration: 200 },
@@ -29,19 +30,13 @@ const DialogWithChart = ({ isOpen, onClose }: DialogWithChartProps) => {
       item && (
         <AnimatedDialogOverlay isOpen={isOpen} onDismiss={onClose} style={{ opacity }}>
           <AnimatedDialogContent aria-label={'trades'}>
-            {swaps && swaps.length > 0 ? (
+            {data && data.length > 0 ? (
               <Wrapper>
                 <CloseChartIcon size={22} onClick={onClose} />
-                <StackedChart
-                  title={'Trades (past month)'}
-                  type={'AREA'}
-                  data={swaps}
-                  isCurrency={false}
-                  showTimeFilter={false}
-                />
+                <StackedChart title={title} type={'AREA'} data={data} isCurrency={false} showTimeFilter={false} />
               </Wrapper>
             ) : (
-              <LocalLoader fill={false} />
+              <LocalLoader fill={false} height={undefined} />
             )}
           </AnimatedDialogContent>
         </AnimatedDialogOverlay>

--- a/src/components/NetworkDataCardWithDialog/index.tsx
+++ b/src/components/NetworkDataCardWithDialog/index.tsx
@@ -4,7 +4,7 @@ import { TYPE } from '../../Theme';
 import { Networks } from '../../constants';
 import { formattedNum } from '../../utils';
 import DialogWithChart from './Dialog';
-import { Content, Header, Icon, OpenChartIcon, Network, NetworkData, Title } from './styled';
+import { Wrapper, Content, Header, Icon, OpenChartIcon, Network, NetworkData, Title } from './styled';
 
 interface NetworksValue {
   [Networks.ARBITRUM_ONE]: string | number;
@@ -14,11 +14,19 @@ interface NetworksValue {
 
 interface NetworkDataCardWithDialogProps {
   title: string;
+  chartTitle: string;
   icon: React.ReactNode;
   networksValues: NetworksValue[];
+  historicalDataHook: any;
 }
 
-const NetworkDataCardWithDialog = ({ title, icon, networksValues }: NetworkDataCardWithDialogProps) => {
+const NetworkDataCardWithDialog = ({
+  title,
+  chartTitle,
+  icon,
+  networksValues,
+  historicalDataHook,
+}: NetworkDataCardWithDialogProps) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const toggleDialog = () => {
@@ -26,24 +34,31 @@ const NetworkDataCardWithDialog = ({ title, icon, networksValues }: NetworkDataC
   };
 
   return (
-    <>
+    <Wrapper>
       <Header>
         <Title>
           <Icon>{icon}</Icon>
           <TYPE.header fontSize={16}>{title}</TYPE.header>
         </Title>
-        <OpenChartIcon size={22} onClick={toggleDialog} />
+        <OpenChartIcon size={24} onClick={toggleDialog} />
       </Header>
       <Content>
-        {Object.keys(networksValues).map((network) => (
-          <NetworkData key={network} margin={false}>
+        {Object.keys(networksValues).map((network, index) => (
+          <NetworkData key={network} margin={index !== networksValues.length - 1}>
             <Network>{network}</Network>
             <TYPE.main fontSize={15}>{formattedNum(networksValues[network])}</TYPE.main>
           </NetworkData>
         ))}
       </Content>
-      {isDialogOpen && <DialogWithChart isOpen={isDialogOpen} onClose={toggleDialog} />}
-    </>
+      {isDialogOpen && (
+        <DialogWithChart
+          title={chartTitle}
+          historicalDataHook={historicalDataHook}
+          isOpen={isDialogOpen}
+          onClose={toggleDialog}
+        />
+      )}
+    </Wrapper>
   );
 };
 

--- a/src/components/NetworkDataCardWithDialog/styled.tsx
+++ b/src/components/NetworkDataCardWithDialog/styled.tsx
@@ -2,10 +2,8 @@ import { BarChart2 } from 'react-feather';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  height: 163px;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
 `;
 
 const Header = styled.div`
@@ -49,8 +47,6 @@ const Content = styled.div`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  padding-left: 10%;
-  padding-right: 10%;
 `;
 
 const NetworkData = styled.div`

--- a/src/components/NetworkDataCardWithDialog/styled.tsx
+++ b/src/components/NetworkDataCardWithDialog/styled.tsx
@@ -1,5 +1,12 @@
-import { Maximize2 } from 'react-feather';
+import { BarChart2 } from 'react-feather';
 import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  height: 163px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
 
 const Header = styled.div`
   display: flex;
@@ -15,10 +22,10 @@ const Title = styled.div`
 `;
 
 const Icon = styled.div`
-  margin-right: 8px;
+  margin-right: 10px;
 `;
 
-const OpenChartIcon = styled(Maximize2)`
+const OpenChartIcon = styled(BarChart2)`
   color: ${({ theme }) => theme.text2};
 
   &:hover {
@@ -42,6 +49,8 @@ const Content = styled.div`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+  padding-left: 10%;
+  padding-right: 10%;
 `;
 
 const NetworkData = styled.div`
@@ -49,4 +58,4 @@ const NetworkData = styled.div`
   margin-right: 36px;
 `;
 
-export { Header, Title, Icon, OpenChartIcon, Value, Network, Content, NetworkData };
+export { Wrapper, Header, Title, Icon, OpenChartIcon, Value, Network, Content, NetworkData };

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { transparentize } from 'polished';
 import React, { useEffect, useState } from 'react';
-import { DollarSign, FileText } from 'react-feather';
+import { DollarSign, FileText, Repeat, Users } from 'react-feather';
 import { withRouter } from 'react-router-dom';
 import { useMedia } from 'react-use';
 import styled from 'styled-components';
@@ -15,7 +15,14 @@ import NetworkDataCardWithDialog from '../components/NetworkDataCardWithDialog';
 import Panel from '../components/Panel';
 import StackedChart from '../components/StackedChart';
 import { SupportedNetwork } from '../constants';
-import { useDashboardChartData, useDashboardComulativeData, useOneDaySwapsData } from '../contexts/Dashboard';
+import {
+  useDashboardChartData,
+  useDashboardComulativeData,
+  useOneDaySwapsData,
+  useOneDayWalletsData,
+  usePastMonthWalletsData,
+  useSwapsData,
+} from '../contexts/Dashboard';
 import { formattedNum } from '../utils';
 
 const GridRow = styled.div`
@@ -40,9 +47,13 @@ const GridCard = styled.div`
 `;
 
 const PanelLoaderWrapper = ({ isLoading, children }) => <Panel>{isLoading ? <LocalLoader /> : children}</Panel>;
+const CardLoaderWrapper = ({ isLoading, children }) => (
+  <Panel>{isLoading ? <LocalLoader height={'163px'} /> : children}</Panel>
+);
 
 const DashboardPage = () => {
   const oneDayTransactions = useOneDaySwapsData();
+  const oneDayWalletsData = useOneDayWalletsData();
   const chartData = useDashboardChartData();
   const comulativeData = useDashboardComulativeData();
   const [formattedLiquidityData, setFormattedLiquidityData] = useState([]);
@@ -115,11 +126,12 @@ const DashboardPage = () => {
   const isComulativeDataLoading =
     formattedComulativeData.trades.length === 0 || formattedComulativeData.volume.length === 0;
   const isLoadingOneDayTransactions = oneDayTransactions === undefined || Object.keys(oneDayTransactions).length === 0;
+  const isLoadingOneDayWallets = oneDayWalletsData === undefined || Object.keys(oneDayWalletsData).length === 0;
 
   return (
     <PageWrapper>
       <ThemedBackground backgroundColor={transparentize(0.8, '#4526A2')} />
-      <ContentWrapper>
+      <ContentWrapper style={{ maxWidth: '1250px' }}>
         <TYPE.largeHeader>{below800 ? 'Analytics Dashboard' : 'Swapr Protocol Analytics Dashboard'}</TYPE.largeHeader>
         {formattedLiquidityData && (
           <>
@@ -131,30 +143,39 @@ const DashboardPage = () => {
                 <PanelLoaderWrapper isLoading={isVolumeAndTvlLoading}>
                   <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
                 </PanelLoaderWrapper>
-                <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
+                <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                   <ComulativeNetworkDataCard
                     title={'All time volume'}
                     icon={<DollarSign size={22} color={'#50dfb6'} />}
                     comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
                     networksValues={formattedComulativeData.volume}
                   />
-                </PanelLoaderWrapper>
-                <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
+                </CardLoaderWrapper>
+                <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                   <ComulativeNetworkDataCard
                     title={'Total transactions'}
                     icon={<FileText size={22} color={'#50dfb6'} />}
                     comulativeValue={formattedNum(comulativeData.totalTrades)}
                     networksValues={formattedComulativeData.trades}
                   />
-                </PanelLoaderWrapper>
-                <PanelLoaderWrapper isLoading={isLoadingOneDayTransactions}>
+                </CardLoaderWrapper>
+                <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                   <NetworkDataCardWithDialog
                     title={'Trades (past 24h)'}
                     icon={<FileText size={22} color={'#50dfb6'} />}
                     dialogContent={'content'}
                     networksValues={oneDayTransactions}
                   />
-                </PanelLoaderWrapper>
+                </CardLoaderWrapper>
+                <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
+                  <NetworkDataCardWithDialog
+                    title={'Wallets (past 24h)'}
+                    chartTitle={'Wallets'}
+                    icon={<Users size={22} color={'#50dfb6'} />}
+                    networksValues={oneDayWalletsData}
+                    historicalDataHook={usePastMonthWalletsData}
+                  />
+                </CardLoaderWrapper>
               </AutoColumn>
             ) : below1400 ? (
               <AutoColumn style={{ marginTop: '6px' }} gap={'16px'}>
@@ -165,30 +186,39 @@ const DashboardPage = () => {
                   <StackedChart title={'Volume'} type={'BAR'} data={formattedVolumeData} />
                 </PanelLoaderWrapper>
                 <AutoColumn gap={'16px'}>
-                  <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
+                  <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                     <ComulativeNetworkDataCard
                       title={'All time volume'}
                       icon={<DollarSign size={22} color={'#50dfb6'} />}
                       comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
                       networksValues={formattedComulativeData.volume}
                     />
-                  </PanelLoaderWrapper>
-                  <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
+                  </CardLoaderWrapper>
+                  <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                     <ComulativeNetworkDataCard
                       title={'Total transactions'}
                       icon={<FileText size={22} color={'#50dfb6'} />}
                       comulativeValue={formattedNum(comulativeData.totalTrades)}
                       networksValues={formattedComulativeData.trades}
                     />
-                  </PanelLoaderWrapper>
-                  <PanelLoaderWrapper isLoading={isLoadingOneDayTransactions}>
+                  </CardLoaderWrapper>
+                  <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                     <NetworkDataCardWithDialog
                       title={'Trades (past 24h)'}
                       icon={<FileText size={22} color={'#50dfb6'} />}
                       dialogContent={'content'}
                       networksValues={oneDayTransactions}
                     />
-                  </PanelLoaderWrapper>
+                  </CardLoaderWrapper>
+                  <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
+                    <NetworkDataCardWithDialog
+                      title={'Wallets (past 24h)'}
+                      chartTitle={'Wallets'}
+                      icon={<Users size={22} color={'#50dfb6'} />}
+                      networksValues={oneDayWalletsData}
+                      historicalDataHook={usePastMonthWalletsData}
+                    />
+                  </CardLoaderWrapper>
                 </AutoColumn>
               </AutoColumn>
             ) : (
@@ -203,30 +233,40 @@ const DashboardPage = () => {
                 </GridChart>
                 <div>
                   <GridCard>
-                    <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
+                    <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                       <ComulativeNetworkDataCard
                         title={'All time volume'}
                         icon={<DollarSign size={22} color={'#50dfb6'} />}
                         comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
                         networksValues={formattedComulativeData.volume}
                       />
-                    </PanelLoaderWrapper>
-                    <PanelLoaderWrapper isLoading={isComulativeDataLoading}>
+                    </CardLoaderWrapper>
+                    <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                       <ComulativeNetworkDataCard
                         title={'Total transactions'}
                         icon={<FileText size={22} color={'#50dfb6'} />}
                         comulativeValue={formattedNum(comulativeData.totalTrades)}
                         networksValues={formattedComulativeData.trades}
                       />
-                    </PanelLoaderWrapper>
-                    <PanelLoaderWrapper isLoading={isLoadingOneDayTransactions}>
+                    </CardLoaderWrapper>
+                    <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                       <NetworkDataCardWithDialog
                         title={'Trades (past 24h)'}
-                        icon={<FileText size={22} color={'#50dfb6'} />}
-                        dialogContent={'content'}
+                        chartTitle={'Trades'}
+                        icon={<Repeat size={22} color={'#50dfb6'} />}
                         networksValues={oneDayTransactions}
+                        historicalDataHook={useSwapsData}
                       />
-                    </PanelLoaderWrapper>
+                    </CardLoaderWrapper>
+                    <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
+                      <NetworkDataCardWithDialog
+                        title={'Wallets (past 24h)'}
+                        chartTitle={'Wallets'}
+                        icon={<Users size={22} color={'#50dfb6'} />}
+                        networksValues={oneDayWalletsData}
+                        historicalDataHook={usePastMonthWalletsData}
+                      />
+                    </CardLoaderWrapper>
                   </GridCard>
                 </div>
               </GridRow>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -254,7 +254,7 @@ const DashboardPage = () => {
                       <NetworkDataCardWithDialog
                         title={'Trades (past 24h)'}
                         chartTitle={'Trades'}
-                        icon={<Repeat size={22} color={'#50dfb6'} />}
+                        icon={<Icon icon={<Repeat />} />}
                         networksValues={oneDayTransactions}
                         historicalDataHook={useSwapsData}
                       />

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -10,6 +10,7 @@ import { TYPE, ThemedBackground } from '../Theme';
 import { PageWrapper, ContentWrapper } from '../components';
 import { AutoColumn } from '../components/Column';
 import ComulativeNetworkDataCard from '../components/ComulativeNetworkDataCard';
+import Icon from '../components/Icon';
 import LocalLoader from '../components/LocalLoader';
 import NetworkDataCardWithDialog from '../components/NetworkDataCardWithDialog';
 import Panel from '../components/Panel';
@@ -146,7 +147,7 @@ const DashboardPage = () => {
                 <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                   <ComulativeNetworkDataCard
                     title={'All time volume'}
-                    icon={<DollarSign size={22} color={'#50dfb6'} />}
+                    icon={<Icon icon={<DollarSign />} />}
                     comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
                     networksValues={formattedComulativeData.volume}
                   />
@@ -154,7 +155,7 @@ const DashboardPage = () => {
                 <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                   <ComulativeNetworkDataCard
                     title={'Total transactions'}
-                    icon={<FileText size={22} color={'#50dfb6'} />}
+                    icon={<Icon icon={<FileText />} />}
                     comulativeValue={formattedNum(comulativeData.totalTrades)}
                     networksValues={formattedComulativeData.trades}
                   />
@@ -162,7 +163,7 @@ const DashboardPage = () => {
                 <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                   <NetworkDataCardWithDialog
                     title={'Trades (past 24h)'}
-                    icon={<FileText size={22} color={'#50dfb6'} />}
+                    icon={<Icon icon={<FileText />} />}
                     dialogContent={'content'}
                     networksValues={oneDayTransactions}
                   />
@@ -171,7 +172,7 @@ const DashboardPage = () => {
                   <NetworkDataCardWithDialog
                     title={'Wallets (past 24h)'}
                     chartTitle={'Wallets'}
-                    icon={<Users size={22} color={'#50dfb6'} />}
+                    icon={<Icon icon={<Users />} />}
                     networksValues={oneDayWalletsData}
                     historicalDataHook={usePastMonthWalletsData}
                   />
@@ -189,7 +190,7 @@ const DashboardPage = () => {
                   <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                     <ComulativeNetworkDataCard
                       title={'All time volume'}
-                      icon={<DollarSign size={22} color={'#50dfb6'} />}
+                      icon={<Icon icon={<DollarSign />} />}
                       comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
                       networksValues={formattedComulativeData.volume}
                     />
@@ -197,7 +198,7 @@ const DashboardPage = () => {
                   <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                     <ComulativeNetworkDataCard
                       title={'Total transactions'}
-                      icon={<FileText size={22} color={'#50dfb6'} />}
+                      icon={<Icon icon={<FileText />} />}
                       comulativeValue={formattedNum(comulativeData.totalTrades)}
                       networksValues={formattedComulativeData.trades}
                     />
@@ -205,7 +206,7 @@ const DashboardPage = () => {
                   <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                     <NetworkDataCardWithDialog
                       title={'Trades (past 24h)'}
-                      icon={<FileText size={22} color={'#50dfb6'} />}
+                      icon={<Icon icon={<FileText />} />}
                       dialogContent={'content'}
                       networksValues={oneDayTransactions}
                     />
@@ -214,7 +215,7 @@ const DashboardPage = () => {
                     <NetworkDataCardWithDialog
                       title={'Wallets (past 24h)'}
                       chartTitle={'Wallets'}
-                      icon={<Users size={22} color={'#50dfb6'} />}
+                      icon={<Icon icon={<Users />} />}
                       networksValues={oneDayWalletsData}
                       historicalDataHook={usePastMonthWalletsData}
                     />
@@ -236,7 +237,7 @@ const DashboardPage = () => {
                     <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                       <ComulativeNetworkDataCard
                         title={'All time volume'}
-                        icon={<DollarSign size={22} color={'#50dfb6'} />}
+                        icon={<Icon icon={<DollarSign />} />}
                         comulativeValue={`$ ${formattedNum(comulativeData.totalVolume)}`}
                         networksValues={formattedComulativeData.volume}
                       />
@@ -244,7 +245,7 @@ const DashboardPage = () => {
                     <CardLoaderWrapper isLoading={isComulativeDataLoading}>
                       <ComulativeNetworkDataCard
                         title={'Total transactions'}
-                        icon={<FileText size={22} color={'#50dfb6'} />}
+                        icon={<Icon icon={<FileText />} />}
                         comulativeValue={formattedNum(comulativeData.totalTrades)}
                         networksValues={formattedComulativeData.trades}
                       />
@@ -262,7 +263,7 @@ const DashboardPage = () => {
                       <NetworkDataCardWithDialog
                         title={'Wallets (past 24h)'}
                         chartTitle={'Wallets'}
-                        icon={<Users size={22} color={'#50dfb6'} />}
+                        icon={<Icon icon={<Users />} />}
                         networksValues={oneDayWalletsData}
                         historicalDataHook={usePastMonthWalletsData}
                       />


### PR DESCRIPTION
# Summary

Related to #41 

Done:

- [x] add data card and chart with wallets data (unique wallets that provided liquidity or performed a swap)
- [x] adjust data cards in the dashboard to fill the stacked charts' height
- [x] change chart icon inside data cards
- [x] minor layout changes   

![dashboard](https://user-images.githubusercontent.com/9011637/167495490-f8b1a5bb-bc35-48ed-8711-3876b345986e.png)
![wallets](https://user-images.githubusercontent.com/9011637/167495506-a2c086d1-6a89-4440-a295-fb756e193a42.png)


# How To Test
1.  Open the page `dashboard`
- [ ] Verify it contains the `wallets` data card with the history chart

# Background

The chart loading is pretty slow (same as the trades' one), especially when loading the data for the `Gnosis chain`; `Gnosis` takes up to an average of ~1.3s per query (when returning 1000 results), compare to 800ms for the others chains. So the chart loading total time is around 1-1.5m.