### PR TITLE
fix mobile view bugs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,6 +46,7 @@ const ContentWrapper = styled.div`
 `;
 
 const Center = styled.div`
+  z-index: 1;
   height: 100%;
   transition: width 0.25s ease;
   background-color: ${({ theme }) => theme.onlyLight};

--- a/src/Theme/index.js
+++ b/src/Theme/index.js
@@ -219,7 +219,6 @@ export const GlobalStyle = createGlobalStyle`
 	color: #20262E;
 	background-color: rgba(255, 255, 255, 0.23);
 	text-align: left;
-	z-index: 10;
   pointer-events: none;
 }
 
@@ -232,7 +231,6 @@ export const GlobalStyle = createGlobalStyle`
 	color: white;
 	background-color: rgba(255, 255, 255, 0.23);
 	text-align: left;
-	z-index: 10;
   pointer-events: none;
 }
 

--- a/src/components/DoubleLogo/index.js
+++ b/src/components/DoubleLogo/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import TokenLogo from '../TokenLogo';
 
 const TokenWrapper = styled.div`
+  z-index: 0;
   position: relative;
   display: flex;
   flex-direction: row;

--- a/src/components/DropdownSelect/index.js
+++ b/src/components/DropdownSelect/index.js
@@ -19,7 +19,6 @@ const NetworkLogo = {
 };
 
 const Wrapper = styled.div`
-  z-index: 1;
   position: relative;
   background-color: ${({ theme }) => theme.panelColor};
   border: 1px solid ${({ color, theme }) => color || theme.primary4};
@@ -49,6 +48,7 @@ const IconWrapper = styled.span`
 `;
 
 const Dropdown = styled.div`
+  z-index: 2;
   position: absolute;
   top: 38px;
   padding-top: 40px;

--- a/src/components/GlobalChart/index.js
+++ b/src/components/GlobalChart/index.js
@@ -103,7 +103,7 @@ const GlobalChart = ({
             bottom: '70px',
             position: 'absolute',
             left: '20px',
-            zIndex: 10,
+            zIndex: 2,
           }}
         >
           <OptionButton

--- a/src/components/NetworkDataCardWithDialog/Dialog/styled.tsx
+++ b/src/components/NetworkDataCardWithDialog/Dialog/styled.tsx
@@ -1,4 +1,5 @@
 import { DialogContent, DialogOverlay } from '@reach/dialog';
+import '@reach/dialog/styles.css';
 import { Minimize2 } from 'react-feather';
 import styled from 'styled-components';
 
@@ -14,15 +15,17 @@ const CloseChartIcon = styled(Minimize2)`
 `;
 
 const StyledDialogContent = styled(DialogContent)`
-  width: 50vw;
-  max-height: 380px;
-  height: 100%;
-  margin: 10vh auto;
-  border-radius: 8px;
-  border: ${({ theme }) => `1px solid ${theme.bg3}`};
-  background-color: #1f2026;
-  padding: 1.25rem;
-  outline: none;
+  &[data-reach-dialog-content] {
+    width: 50vw;
+    max-height: 380px;
+    height: 100%;
+    margin: 10vh auto;
+    border-radius: 8px;
+    border: ${({ theme }) => `1px solid ${theme.bg3}`};
+    background: #1f2026;
+    padding: 1.25rem;
+    outline: none;
+  }
 `;
 
 const StyledDialogOverlay = styled(DialogOverlay)`

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -20,7 +20,6 @@ import TokenLogo from '../TokenLogo';
 
 const Container = styled.div`
   height: 48px;
-  z-index: 30;
   position: relative;
 
   @media screen and (max-width: 600px) {
@@ -39,7 +38,6 @@ const Wrapper = styled.div`
   background: ${({ theme }) => transparentize(0.4, theme.bg6)};
   border-bottom-right-radius: ${({ open }) => (open ? '0px' : '12px')};
   border-bottom-left-radius: ${({ open }) => (open ? '0px' : '12px')};
-  z-index: 9999;
   width: 100%;
   min-width: 300px;
   box-sizing: border-box;
@@ -105,9 +103,10 @@ const CloseIcon = styled(X)`
 `;
 
 const Menu = styled.div`
+  position: absolute;
+  z-index: 3;
   display: flex;
   flex-direction: column;
-  z-index: 9999;
   width: 100%;
   top: 50px;
   max-height: 540px;

--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -24,7 +24,7 @@ const Wrapper = styled.div`
   padding: 0.5rem 0.5rem 0.5rem 0.75rem;
   position: sticky;
   top: 0px;
-  z-index: 1;
+  z-index: 2;
   box-sizing: border-box;
   /* background-color: #1b1c22; */
   background: linear-gradient(193.68deg, #1b1c22 0.68%, #000000 100.48%);

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -166,6 +166,7 @@ const DashboardPage = () => {
                     icon={<Icon icon={<FileText />} />}
                     dialogContent={'content'}
                     networksValues={oneDayTransactions}
+                    historicalDataHook={useSwapsData}
                   />
                 </CardLoaderWrapper>
                 <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
@@ -209,6 +210,7 @@ const DashboardPage = () => {
                       icon={<Icon icon={<FileText />} />}
                       dialogContent={'content'}
                       networksValues={oneDayTransactions}
+                      historicalDataHook={useSwapsData}
                     />
                   </CardLoaderWrapper>
                   <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>


### PR DESCRIPTION
# Summary

There were multiple inconsistencies with elements overlapping when opening dropdowns, especially in the mobile viewport; this PR fixes them.

![1](https://user-images.githubusercontent.com/9011637/167941286-cc8f3965-aa51-4095-863e-608802ac4514.png)
![2](https://user-images.githubusercontent.com/9011637/167941289-0d90ad1b-8f22-4edc-b647-dd522f882eef.png)
![3](https://user-images.githubusercontent.com/9011637/167941290-65d18227-a38b-4cdf-b9b8-53289810f30b.png)
![4](https://user-images.githubusercontent.com/9011637/167941292-d1ef4a1c-8cbf-4915-8056-be7f3782d776.png)
![5](https://user-images.githubusercontent.com/9011637/167941293-dbbad7c0-9b15-40f2-b6b4-5a9ad36c2ce0.png)

# How To Test
1.  Switch to mobile view
- [ ] Navigate on all pages and open the bar menu, there shouldn't be any more overlapping
- [ ] Navigate to the `overview` page and open the `liquidy/volume` dropdown of the chart, you should correctly see the dropdown value