### PR TITLE
feat: optimize mints and swaps queries

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -461,31 +461,30 @@ export const DASHBOARD_SWAPS_HISTORY = gql`
   }
 `;
 
-export const DASHBOARD_MINTS_AND_SWAPS_TRANSACTIONS_WITH_TIMESTAMP = gql`
-  query transactions($lastId: ID!, $startTime: Int!) {
-    transactions(first: 1000, where: { id_gt: $lastId, timestamp_gt: $startTime }) {
+export const DASHBOARD_MINTS_AND_SWAPS_WITH_TIMESTAMP = gql`
+  query ($lastMintId: ID!, $lastSwapId: ID!, $startTime: Int!) {
+    mints(first: 1000, where: { id_gt: $lastMintId, timestamp_gt: $startTime }) {
       id
+      to
       timestamp
-      mints {
-        to
-      }
-      swaps {
-        to
-      }
+    }
+    swaps(first: 1000, where: { id_gt: $lastSwapId, timestamp_gt: $startTime }) {
+      id
+      to
+      timestamp
     }
   }
 `;
 
-export const DASHBOARD_MINTS_AND_SWAPS_TRANSACTIONS = gql`
-  query transactions($lastId: ID!, $startTime: Int!) {
-    transactions(first: 1000, where: { id_gt: $lastId, timestamp_gt: $startTime }) {
+export const DASHBOARD_MINTS_AND_SWAPS = gql`
+  query ($lastMintId: ID!, $lastSwapId: ID!, $startTime: Int!) {
+    mints(first: 1000, where: { id_gt: $lastMintId, timestamp_gt: $startTime }) {
       id
-      mints {
-        to
-      }
-      swaps {
-        to
-      }
+      to
+    }
+    swaps(first: 1000, where: { id_gt: $lastSwapId, timestamp_gt: $startTime }) {
+      id
+      to
     }
   }
 `;


### PR DESCRIPTION
# Summary

Optimize the `swaps` and `mints` queries by querying the two entities directly at the same time.

|Before |After |
--- | --- |
|2:27m|1:40m|
|2:10m|1:57m|
|2:15m|1:46m|

With these changes, the chart should load faster by at least ~20s.

# How To Test
1.  Open the page `dashboard`
- [ ] The `Wallets` history chart should load a bit faster