### PR TITLE
Fix rewards path to swapr.eth.limo

### DIFF
--- a/src/components/FarmingList/ListItem.tsx
+++ b/src/components/FarmingList/ListItem.tsx
@@ -221,7 +221,7 @@ export default function ListItem({ pairData, index }: ListItemProps) {
             style={{ whiteSpace: 'nowrap' }}
             external={true}
             href={getSwaprLink(
-              `/rewards/${pairData.stakablePair.token0.id}/${pairData.stakablePair.token1.id}/${pairData.id}`,
+              `/rewards/campaign/${pairData.stakablePair.token0.id}/${pairData.stakablePair.token1.id}/${pairData.id}`,
               ChainId[selectedNetwork],
             )}
           >


### PR DESCRIPTION
Fix rewards path to swapr.eth.limo

This needs to be merged once swapr changes are deployed