### PR TITLE
fix: wrong data aggregation

### DIFF
--- a/src/contexts/Dashboard.js
+++ b/src/contexts/Dashboard.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import dayOfYear from 'dayjs/plugin/dayOfYear';
+import utc from 'dayjs/plugin/utc';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useReducer, useState, createContext, useContext, useMemo } from 'react';
 
@@ -16,6 +17,7 @@ import { SupportedNetwork } from '../constants';
 import { getTimeframe } from '../utils';
 import { useTimeframe } from './Application';
 
+dayjs.extend(utc);
 dayjs.extend(dayOfYear);
 
 const DashboardDataContext = createContext();
@@ -406,8 +408,7 @@ const getOneDayWallets = async () => {
   try {
     let swapsAndMints = [];
 
-    const utcCurrentTime = dayjs();
-    const utcOneDayBack = utcCurrentTime.subtract(1, 'day').startOf('minute').unix();
+    const utcOneDayBack = dayjs.utc().startOf('day').unix();
 
     for (const { client, network } of SUPPORTED_CLIENTS) {
       let lastMintId = '';
@@ -471,8 +472,7 @@ const getPastMonthWallets = async () => {
   try {
     let swapsAndMints = [];
 
-    const utcCurrentTime = dayjs();
-    const utcOneDayBack = utcCurrentTime.subtract(1, 'month').startOf('minute').unix();
+    const utcOneDayBack = dayjs.utc().subtract(1, 'month').startOf('day').unix();
 
     for (const { client, network } of SUPPORTED_CLIENTS) {
       let lastMintId = '';
@@ -503,32 +503,28 @@ const getPastMonthWallets = async () => {
       }
     }
 
-    let uniqueWallets = {};
-    swapsAndMints.forEach(({ network, timestamp, to }) => {
-      uniqueWallets[to] = {
-        timestamp,
-        network,
-      };
-    });
-    uniqueWallets = Object.values(uniqueWallets);
-
-    const stackedWallets = uniqueWallets.reduce((accumulator, current) => {
-      const dayOfTheYear = dayjs.unix(current.timestamp).dayOfYear();
+    const stackedWallets = swapsAndMints.reduce((accumulator, current) => {
+      const dayOfTheYear = dayjs.unix(current.timestamp).utc().startOf('day').dayOfYear();
 
       return {
         ...accumulator,
         [dayOfTheYear]: {
           ...accumulator[dayOfTheYear],
-          time: dayjs().dayOfYear(dayOfTheYear).utc().format('YYYY-MM-DD'),
-          [current.network]:
-            accumulator[dayOfTheYear] && accumulator[dayOfTheYear][current.network]
-              ? Number(accumulator[dayOfTheYear][current.network]) + 1
-              : 1,
+          time: dayjs.utc().dayOfYear(dayOfTheYear).startOf('day').format('YYYY-MM-DD'),
+          [current.network]: {
+            ...(accumulator[dayOfTheYear] ? accumulator[dayOfTheYear][current.network] : {}),
+            [current.to]: true,
+          },
         },
       };
     }, {});
 
-    return Object.values(stackedWallets);
+    return Object.values(stackedWallets).map((stackedValue) => ({
+      time: stackedValue.time,
+      [SupportedNetwork.MAINNET]: Object.keys(stackedValue[SupportedNetwork.MAINNET]).length,
+      [SupportedNetwork.XDAI]: Object.keys(stackedValue[SupportedNetwork.XDAI]).length,
+      [SupportedNetwork.ARBITRUM_ONE]: Object.keys(stackedValue[SupportedNetwork.ARBITRUM_ONE]).length,
+    }));
   } catch (error) {
     console.error(error);
   }
@@ -541,8 +537,7 @@ const getPastMonthSwaps = async () => {
   try {
     let swaps = [];
 
-    const utcCurrentTime = dayjs();
-    const utcOneMonthBack = utcCurrentTime.subtract(1, 'month').startOf('minute').unix();
+    const utcOneMonthBack = dayjs.utc().subtract(1, 'month').startOf('day').unix();
 
     for (const { client, network } of SUPPORTED_CLIENTS) {
       let lastId = '';
@@ -568,13 +563,13 @@ const getPastMonthSwaps = async () => {
     }
 
     const stackedSwaps = swaps.reduce((accumulator, current) => {
-      const dayOfTheYear = dayjs.unix(current.swap.timestamp).dayOfYear();
+      const dayOfTheYear = dayjs.unix(current.swap.timestamp).utc().startOf('day').dayOfYear();
 
       return {
         ...accumulator,
         [dayOfTheYear]: {
           ...accumulator[dayOfTheYear],
-          time: dayjs().dayOfYear(dayOfTheYear).utc().format('YYYY-MM-DD'),
+          time: dayjs.utc().dayOfYear(dayOfTheYear).startOf('day').format('YYYY-MM-DD'),
           [current.network]:
             accumulator[dayOfTheYear] && accumulator[dayOfTheYear][current.network]
               ? Number(accumulator[dayOfTheYear][current.network]) + 1
@@ -596,8 +591,7 @@ const getOneDaySwaps = async () => {
   try {
     let swaps = [];
 
-    const utcCurrentTime = dayjs();
-    const utcOneDayBack = utcCurrentTime.subtract(1, 'day').startOf('minute').unix();
+    const utcOneDayBack = dayjs.utc().startOf('day').unix();
 
     for (const { client, network } of SUPPORTED_CLIENTS) {
       let lastId = '';

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -162,7 +162,7 @@ const DashboardPage = () => {
                 </CardLoaderWrapper>
                 <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                   <NetworkDataCardWithDialog
-                    title={'Trades (past 24h)'}
+                    title={'Trades (today)'}
                     icon={<Icon icon={<FileText />} />}
                     dialogContent={'content'}
                     networksValues={oneDayTransactions}
@@ -170,7 +170,7 @@ const DashboardPage = () => {
                 </CardLoaderWrapper>
                 <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
                   <NetworkDataCardWithDialog
-                    title={'Wallets (past 24h)'}
+                    title={'Wallets (today)'}
                     chartTitle={'Wallets'}
                     icon={<Icon icon={<Users />} />}
                     networksValues={oneDayWalletsData}
@@ -205,7 +205,7 @@ const DashboardPage = () => {
                   </CardLoaderWrapper>
                   <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                     <NetworkDataCardWithDialog
-                      title={'Trades (past 24h)'}
+                      title={'Trades (today)'}
                       icon={<Icon icon={<FileText />} />}
                       dialogContent={'content'}
                       networksValues={oneDayTransactions}
@@ -213,7 +213,7 @@ const DashboardPage = () => {
                   </CardLoaderWrapper>
                   <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
                     <NetworkDataCardWithDialog
-                      title={'Wallets (past 24h)'}
+                      title={'Wallets (today)'}
                       chartTitle={'Wallets'}
                       icon={<Icon icon={<Users />} />}
                       networksValues={oneDayWalletsData}
@@ -252,7 +252,7 @@ const DashboardPage = () => {
                     </CardLoaderWrapper>
                     <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
                       <NetworkDataCardWithDialog
-                        title={'Trades (past 24h)'}
+                        title={'Trades (today)'}
                         chartTitle={'Trades'}
                         icon={<Icon icon={<Repeat />} />}
                         networksValues={oneDayTransactions}
@@ -261,7 +261,7 @@ const DashboardPage = () => {
                     </CardLoaderWrapper>
                     <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
                       <NetworkDataCardWithDialog
-                        title={'Wallets (past 24h)'}
+                        title={'Wallets (today)'}
                         chartTitle={'Wallets'}
                         icon={<Icon icon={<Users />} />}
                         networksValues={oneDayWalletsData}


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/9011637/169155626-982e0530-5121-4365-9853-dfcbd7974fae.png)

Fix a bug that was causing an erroneous data aggregation regarding the `Trades` and `Wallets` cards & charts.
The problem caused confusion since the 24h data wasn't matching with the latest values displayed by the corresponding chart.

Done:
- [x] fixed the dates and aggregation inconsistencies
- [x] display the current day values in the data cards (instead of 24h)

# How To Test
1.  Open the page `dashboard`
- [ ] Verify that the values in the data cards for `trades` and `wallets` match with the last point of the linked chart

# Background

There may be the case when the values still don't match, but that's because the chart loading takes a while, and in the meantime there could be new transactions (in any case it's a minor difference)
