### PR TITLE
fix: add pool prefix to links

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -59,7 +59,7 @@ export function getPoolLink(
 ) {
   if (!token1Address) {
     return (
-      `${SWAPR_LINK}` +
+      `${SWAPR_LINK}/pools/` +
       (remove ? `remove` : `add`) +
       `/${token0Address === nativeCurrencyWrapper.symbol ? nativeCurrency : token0Address}/${nativeCurrency}?chainId=${
         ChainId[selectedNetwork]
@@ -67,7 +67,7 @@ export function getPoolLink(
     );
   } else {
     return (
-      `${SWAPR_LINK}` +
+      `${SWAPR_LINK}/pools/` +
       (remove ? `remove` : `add`) +
       `/${token0Address === nativeCurrencyWrapper.symbol ? nativeCurrency : token0Address}/${
         token1Address === nativeCurrencyWrapper.symbol ? nativeCurrency : token1Address


### PR DESCRIPTION
# Summary

Fixes #75 

Add `/pool` prefix to links pointing to `add` and `remove` liquidity on swapr-dapp.

# How To Test
1.  Open the page `tokens` and click any pair
- [ ] `Add liquidity` button should redirect to `/pools/add`

2. Open the page `accounts` and click any account
- [ ] `Add` and `Remove` buttons, on the positions, should redirect to `/pools/add` and `/pools/remove`

# Background

We should merge this PR when the change to the routes is deployed on swapr-dapp.