### PR TITLE
fix/account-pair-chart

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -40,6 +40,16 @@ export const GET_BLOCK = gql`
   }
 `;
 
+export const GET_BLOCK_BY_TIMESTAMPS = gql`
+  query blocks($timestamps: [Int], $lastId: ID!) {
+    blocks(first: 1000, orderBy: timestamp, orderDirection: asc, where: { id_gt: $lastId, timestamp_in: $timestamps }) {
+      id
+      number
+      timestamp
+    }
+  }
+`;
+
 export const GET_BLOCKS = (timestamps) => {
   let queryString = 'query blocks {';
   queryString += timestamps.map((timestamp) => {
@@ -126,14 +136,6 @@ export const SHARE_VALUE = (pairAddress, blocks) => {
         token1{
           derivedNativeCurrency
         }
-      }
-    `,
-  );
-  queryString += ',';
-  queryString += blocks.map(
-    (block) => `
-      b${block.timestamp}: bundle(id:"1", block: { number: ${block.number} }) { 
-        nativeCurrencyPrice
       }
     `,
   );

--- a/src/components/LocalLoader/index.js
+++ b/src/components/LocalLoader/index.js
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: ${({ height }) => (height ? height : '180px')};
+  min-height: ${({ height }) => (height ? `${height}px` : '180px')};
   width: 100%;
 
   ${(props) =>

--- a/src/components/PairReturnsChart/index.js
+++ b/src/components/PairReturnsChart/index.js
@@ -56,43 +56,44 @@ const PairReturnsChart = ({ account, position }) => {
 
   return (
     <ChartWrapper>
-      {below600 ? (
-        <RowBetween mb={40}>
-          <div />
-          <DropdownSelect options={timeframeOptions} active={timeWindow} setActive={setTimeWindow} />
-        </RowBetween>
-      ) : (
-        <OptionsRow>
-          <AutoRow gap="6px" style={{ flexWrap: 'nowrap' }}>
-            <OptionButton active={chartView === CHART_VIEW.VALUE} onClick={() => setChartView(CHART_VIEW.VALUE)}>
-              Liquidity
-            </OptionButton>
-            <OptionButton active={chartView === CHART_VIEW.FEES} onClick={() => setChartView(CHART_VIEW.FEES)}>
-              Fees
-            </OptionButton>
-          </AutoRow>
-          <AutoRow justify="flex-end" gap="6px">
-            <OptionButton
-              active={timeWindow === timeframeOptions.WEEK}
-              onClick={() => setTimeWindow(timeframeOptions.WEEK)}
-            >
-              1W
-            </OptionButton>
-            <OptionButton
-              active={timeWindow === timeframeOptions.MONTH}
-              onClick={() => setTimeWindow(timeframeOptions.MONTH)}
-            >
-              1M
-            </OptionButton>
-            <OptionButton
-              active={timeWindow === timeframeOptions.ALL_TIME}
-              onClick={() => setTimeWindow(timeframeOptions.ALL_TIME)}
-            >
-              All
-            </OptionButton>
-          </AutoRow>
-        </OptionsRow>
-      )}
+      {data &&
+        (below600 ? (
+          <RowBetween mb={40}>
+            <div />
+            <DropdownSelect options={timeframeOptions} active={timeWindow} setActive={setTimeWindow} />
+          </RowBetween>
+        ) : (
+          <OptionsRow>
+            <AutoRow gap="6px" style={{ flexWrap: 'nowrap' }}>
+              <OptionButton active={chartView === CHART_VIEW.VALUE} onClick={() => setChartView(CHART_VIEW.VALUE)}>
+                Liquidity
+              </OptionButton>
+              <OptionButton active={chartView === CHART_VIEW.FEES} onClick={() => setChartView(CHART_VIEW.FEES)}>
+                Fees
+              </OptionButton>
+            </AutoRow>
+            <AutoRow justify="flex-end" gap="6px">
+              <OptionButton
+                active={timeWindow === timeframeOptions.WEEK}
+                onClick={() => setTimeWindow(timeframeOptions.WEEK)}
+              >
+                1W
+              </OptionButton>
+              <OptionButton
+                active={timeWindow === timeframeOptions.MONTH}
+                onClick={() => setTimeWindow(timeframeOptions.MONTH)}
+              >
+                1M
+              </OptionButton>
+              <OptionButton
+                active={timeWindow === timeframeOptions.ALL_TIME}
+                onClick={() => setTimeWindow(timeframeOptions.ALL_TIME)}
+              >
+                All
+              </OptionButton>
+            </AutoRow>
+          </OptionsRow>
+        ))}
       <ResponsiveContainer aspect={aspect}>
         {data ? (
           <LineChart margin={{ top: 0, right: 0, bottom: 0, left: 0 }} barCategoryGap={1} data={data}>

--- a/src/components/UserChart/index.js
+++ b/src/components/UserChart/index.js
@@ -15,8 +15,7 @@ import LocalLoader from '../LocalLoader';
 import { AutoRow, RowBetween } from '../Row';
 
 const ChartWrapper = styled.div`
-  height: 100%;
-  max-height: 390px;
+  max-height: 420px;
 
   @media screen and (max-width: 600px) {
     min-height: 200px;
@@ -41,40 +40,46 @@ const UserChart = ({ account }) => {
 
   return (
     <ChartWrapper>
-      {below600 ? (
-        <RowBetween mb={40}>
-          <div />
-          <DropdownSelect options={timeframeOptions} active={timeWindow} setActive={setTimeWindow} color={'#4526A2'} />
-        </RowBetween>
-      ) : (
-        <RowBetween mb={40}>
-          <AutoRow gap="10px">
-            <TYPE.main>Liquidity Value</TYPE.main>
-          </AutoRow>
-          <AutoRow justify="flex-end" gap="4px">
-            <OptionButton
-              active={timeWindow === timeframeOptions.MONTH}
-              onClick={() => setTimeWindow(timeframeOptions.MONTH)}
-            >
-              1M
-            </OptionButton>
-            <OptionButton
-              active={timeWindow === timeframeOptions.WEEK}
-              onClick={() => setTimeWindow(timeframeOptions.WEEK)}
-            >
-              1W
-            </OptionButton>
-            <OptionButton
-              active={timeWindow === timeframeOptions.ALL_TIME}
-              onClick={() => setTimeWindow(timeframeOptions.ALL_TIME)}
-            >
-              All
-            </OptionButton>
-          </AutoRow>
-        </RowBetween>
-      )}
+      {chartData &&
+        (below600 ? (
+          <RowBetween mb={40}>
+            <div />
+            <DropdownSelect
+              options={timeframeOptions}
+              active={timeWindow}
+              setActive={setTimeWindow}
+              color={'#4526A2'}
+            />
+          </RowBetween>
+        ) : (
+          <RowBetween mb={40}>
+            <AutoRow gap="10px">
+              <TYPE.main>Liquidity Value</TYPE.main>
+            </AutoRow>
+            <AutoRow justify="flex-end" gap="4px">
+              <OptionButton
+                active={timeWindow === timeframeOptions.MONTH}
+                onClick={() => setTimeWindow(timeframeOptions.MONTH)}
+              >
+                1M
+              </OptionButton>
+              <OptionButton
+                active={timeWindow === timeframeOptions.WEEK}
+                onClick={() => setTimeWindow(timeframeOptions.WEEK)}
+              >
+                1W
+              </OptionButton>
+              <OptionButton
+                active={timeWindow === timeframeOptions.ALL_TIME}
+                onClick={() => setTimeWindow(timeframeOptions.ALL_TIME)}
+              >
+                All
+              </OptionButton>
+            </AutoRow>
+          </RowBetween>
+        ))}
       {chartData ? (
-        <ResponsiveContainer aspect={aspect} style={{ height: 'inherit' }}>
+        <ResponsiveContainer aspect={aspect}>
           <AreaChart margin={{ top: 0, right: 10, bottom: 6, left: 0 }} barCategoryGap={1} data={chartData}>
             <defs>
               <linearGradient id="colorUv" x1="0" y1="0" x2="0" y2="1">

--- a/src/contexts/User.js
+++ b/src/contexts/User.js
@@ -316,7 +316,7 @@ export function useUserPositionChart(position, account) {
   const currentPairData = usePairData(pairAddress);
   const [currentNativeCurrencyPrice] = useNativeCurrencyPrice();
 
-  // formatetd array to return for chart data
+  // formatted array to return for chart data
   const formattedHistory = state?.[account]?.[USER_PAIR_RETURNS_KEY]?.[pairAddress];
 
   useEffect(() => {


### PR DESCRIPTION
# Summary

Fixes #79

The `liquidity/fees` chart for a single pair on the account page wasn't loading; these changes solve this.
There was also a small layout bug with the chart.

![before](https://user-images.githubusercontent.com/9011637/172347769-adb19983-0f84-4fe8-9bf6-a6cbfce44383.png)
![after_1](https://user-images.githubusercontent.com/9011637/172347795-91c832e1-1cf4-4b0a-a156-4aadcfd54f73.png)
![after_2](https://user-images.githubusercontent.com/9011637/172347799-3ae13139-dfab-4e2f-8be0-8b8ec46a8316.png)

# How To Test
1.  Open the page `Accounts`
- [ ] Pick any account and verify that the `liquidity/fees` chart for each pair works.