### PR TITLE
fetch the first 200 pairs

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -840,7 +840,7 @@ export const MINING_POSITIONS = (account) => {
 export const PAIRS_BULK = gql`
   ${PairFields}
   query pairs($allPairs: [Bytes]!) {
-    pairs(where: { id_in: $allPairs }, orderBy: trackedReserveNativeCurrency, orderDirection: desc) {
+    pairs(first: 200, where: { id_in: $allPairs }, orderBy: trackedReserveNativeCurrency, orderDirection: desc) {
       ...PairFields
     }
   }


### PR DESCRIPTION
# Summary

Fixes #66

Display the first 200 pairs on the `pairs` page, just like the `tokens` page.

# How To Test

1.  Open the page `pairs`
- [ ] Verify it displays 200 pairs