### PR TITLE
fix slow loading of top pairs

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -53,7 +53,7 @@ export const GET_BLOCK_BY_TIMESTAMPS = gql`
 export const GET_BLOCKS = (timestamps) => {
   let queryString = 'query blocks {';
   queryString += timestamps.map((timestamp) => {
-    return `t${timestamp}:blocks(first: 1, orderBy: number, orderDirection: asc, where: { timestamp_gt: ${timestamp} }) {
+    return `t${timestamp}:blocks(first: 1000, orderBy: number, orderDirection: asc, where: { timestamp_gt: ${timestamp} }) {
       number
     }`;
   });


### PR DESCRIPTION
# Summary

Fix the slow loading of the top 200 pairs on the overview page, which was causing the queries to take more than `50s`.

# How To Test
1.  Open the page `overview`
- [ ] The `top pairs` list should now load fast

# Background

After digging and trying to optimize the query, I found out that it's a lot faster to query for the first `1000` entities and pick the first one than ask only for the first one directly in the query.