### PR TITLE
fee receiver lookup from dashboard

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -217,8 +217,9 @@ export const FIRST_SNAPSHOT = gql`
 `;
 
 export const USER_HISTORY = gql`
-  query snapshots($user: Bytes!, $skip: Int!) {
-    liquidityPositionSnapshots(first: 1000, skip: $skip, where: { user: $user }) {
+  query snapshots($lastId: ID!, $user: Bytes!) {
+    liquidityPositionSnapshots(first: 1000, where: { id_gt: $lastId, user: $user }) {
+      id
       timestamp
       reserveUSD
       liquidityTokenBalance
@@ -245,8 +246,9 @@ export const USER_HISTORY = gql`
 `;
 
 export const USER_HISTORY_STAKE = gql`
-  query snapshots($user: Bytes!, $skip: Int!) {
-    liquidityMiningPositionSnapshots(first: 1000, skip: $skip, where: { user: $user }) {
+  query snapshots($lastId: ID!, $user: Bytes!) {
+    liquidityMiningPositionSnapshots(first: 1000, where: { id_gt: $lastId, user: $user }) {
+      id
       timestamp
       reserveUSD
       liquidityTokenBalance: stakedLiquidityTokenBalance
@@ -359,9 +361,11 @@ export const USER_TRANSACTIONS = gql`
       pair {
         id
         token0 {
+          id
           symbol
         }
         token1 {
+          id
           symbol
         }
       }
@@ -379,10 +383,13 @@ export const USER_TRANSACTIONS = gql`
         timestamp
       }
       pair {
+        id
         token0 {
+          id
           symbol
         }
         token1 {
+          id
           symbol
         }
       }

--- a/src/components/ComulativeNetworkDataCard/index.js
+++ b/src/components/ComulativeNetworkDataCard/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { Typography } from '../../Theme';
 import { Wrapper, Header, Value, Content, Network, Data, NetworkData, Title } from './styled';
 
-const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
+const DataCard = ({ title, icon, comulativeValue, networksValues, customNetworkAction }) => (
   <Wrapper>
     <Header>
       <Title>
@@ -16,7 +16,11 @@ const DataCard = ({ title, icon, comulativeValue, networksValues }) => (
     <Content>
       {networksValues.map(({ network, value }, index) => (
         <NetworkData key={network} align={index === networksValues.length - 1 ? 'right' : 'left'}>
-          <Network>{network}</Network>
+          <Network>
+            {customNetworkAction &&
+              React.cloneElement(customNetworkAction, { onClick: () => customNetworkAction.props.onClick(network) })}
+            {network}
+          </Network>
           <Data>{value}</Data>
         </NetworkData>
       ))}
@@ -29,6 +33,7 @@ DataCard.propTypes = {
   icon: PropTypes.node,
   comulativeValue: PropTypes.any,
   networksValues: PropTypes.array,
+  customNetworkAction: PropTypes.node,
 };
 
 export default DataCard;

--- a/src/components/ComulativeNetworkDataCard/index.js
+++ b/src/components/ComulativeNetworkDataCard/index.js
@@ -15,7 +15,11 @@ const DataCard = ({ title, icon, comulativeValue, networksValues, customNetworkA
     </Header>
     <Content>
       {networksValues.map(({ network, value }, index) => (
-        <NetworkData key={network} align={index === networksValues.length - 1 ? 'right' : 'left'}>
+        <NetworkData
+          key={network}
+          align={index === networksValues.length - 1 ? 'right' : 'left'}
+          marginBottom={index === networksValues.length - 1 ? '0' : '16px'}
+        >
           <Network>
             {customNetworkAction &&
               React.cloneElement(customNetworkAction, { onClick: () => customNetworkAction.props.onClick(network) })}

--- a/src/components/ComulativeNetworkDataCard/styled.js
+++ b/src/components/ComulativeNetworkDataCard/styled.js
@@ -11,12 +11,20 @@ const Header = styled.div`
   justify-content: space-between;
   flex-wrap: wrap;
   margin-bottom: 16px;
+
+  @media screen and (max-width: 370px) {
+    flex-direction: column;
+    margin-bottom: 0;
+  }
 `;
 
 const Title = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
+
+  @media screen and (max-width: 370px) {
+    margin-bottom: 16px;
+  }
 `;
 
 const Icon = styled.div`
@@ -56,11 +64,20 @@ const Content = styled.div`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+
+  @media screen and (max-width: 370px) {
+    display: block;
+  }
 `;
 
 const NetworkData = styled.div`
   text-align: ${({ align }) => align};
   text-transform: uppercase;
+
+  @media screen and (max-width: 370px) {
+    text-align: left;
+    margin-bottom: ${({ marginBottom }) => marginBottom};
+  }
 `;
 
 export { Wrapper, Header, Title, Icon, Value, Network, Data, Content, NetworkData };

--- a/src/components/ComulativeNetworkDataCard/styled.js
+++ b/src/components/ComulativeNetworkDataCard/styled.js
@@ -33,6 +33,7 @@ const Value = styled.div`
 `;
 
 const Network = styled.div`
+  display: flex;
   margin-bottom: 8px;
   font-style: normal;
   font-weight: 600;

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -129,6 +129,12 @@ export const MULTICALL_ADDRESS = {
   [SupportedNetwork.ARBITRUM_ONE]: '0xF718F2bd590E5621e53f7b89398e52f7Acced8ca',
 };
 
+export const NETOWRK_FEE_RECEIVER_ADDRESSES = {
+  [Networks.XDAI]: '0x65f29020d07a6cfa3b0bf63d749934d5a6e6ea18',
+  [Networks.MAINNET]: '0xc6130400c1e3cd7b352db75055db9dd554e00ef0',
+  [Networks.ARBITRUM_ONE]: '0x1d7c7cb66fb2d75123351fd0d6779e8d7724a1ae',
+};
+
 export const DEFAULT_BLOCK_DIFFERENCE_THRESHOLD = 30;
 
 export const BLOCK_DIFFERENCE_THRESHOLD = {

--- a/src/hooks/useSwprPrice.ts
+++ b/src/hooks/useSwprPrice.ts
@@ -9,6 +9,10 @@ export function useSwprPrice(): { loading: boolean; price: number } {
   const [loading, setLoading] = useState<boolean>(true);
   const [price, setPrice] = useState<number>(0);
 
+  if (!client) {
+    return { loading: true, price: 0 };
+  }
+
   client
     .query({
       query: GET_SWPR_DERIVED_NATIVE_PRICE,

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -31,7 +31,7 @@ import { formattedNum } from '../utils';
 
 const GridRow = styled.div`
   display: grid;
-  grid-template-columns: minmax(auto, 920px) auto;
+  grid-template-columns: minmax(auto, 900px) auto;
   column-gap: 21px;
   row-gap: 21px;
 `;
@@ -60,7 +60,7 @@ const PanelLoaderWrapper = ({ maxHeight, isLoading, children }) => (
   <Panel maxHeight={maxHeight || '380px'}>{isLoading ? <LocalLoader /> : children}</Panel>
 );
 const CardLoaderWrapper = ({ isLoading, children }) => (
-  <Panel padding={'32px 36px'}>{isLoading ? <LocalLoader height={'163px'} /> : children}</Panel>
+  <Panel padding={'24px'}>{isLoading ? <LocalLoader height={'163px'} /> : children}</Panel>
 );
 
 const DashboardPage = ({ history }) => {
@@ -77,7 +77,7 @@ const DashboardPage = ({ history }) => {
 
   // breakpoints
   const below800 = useMedia('(max-width: 800px)');
-  const below1400 = useMedia('(max-width: 1400px)');
+  const below1540 = useMedia('(max-width: 1510px)');
 
   const handleReceiverLookup = (network) => {
     switchNetwork(network);
@@ -220,7 +220,7 @@ const DashboardPage = ({ history }) => {
                   />
                 </CardLoaderWrapper>
               </AutoColumn>
-            ) : below1400 ? (
+            ) : below1540 ? (
               <AutoColumn style={{ marginTop: '6px' }} gap={'16px'}>
                 <PanelLoaderWrapper maxHeight={'auto'} isLoading={isVolumeAndTvlLoading}>
                   <StackedChart title={'TVL'} type={'AREA'} data={formattedLiquidityData} />

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import React, { useEffect, useMemo, useState } from 'react';
-import { Repeat, Users, Zap } from 'react-feather';
+import { Repeat, Users, Zap, Link } from 'react-feather';
+import { withRouter } from 'react-router-dom';
 import { useMedia } from 'react-use';
 import styled from 'styled-components';
 
@@ -15,7 +16,7 @@ import LocalLoader from '../components/LocalLoader';
 import NetworkDataCardWithDialog from '../components/NetworkDataCardWithDialog';
 import Panel from '../components/Panel';
 import StackedChart from '../components/StackedChart';
-import { SupportedNetwork } from '../constants';
+import { SupportedNetwork, NETOWRK_FEE_RECEIVER_ADDRESSES } from '../constants';
 import {
   useDashboardChartData,
   useDashboardComulativeData,
@@ -25,6 +26,7 @@ import {
   useSwapsData,
   useUncollectedFeesData,
 } from '../contexts/Dashboard';
+import { useSelectedNetworkUpdater } from '../contexts/Network';
 import { formattedNum } from '../utils';
 
 const GridRow = styled.div`
@@ -47,6 +49,13 @@ const GridCard = styled.div`
   row-gap: 21px;
 `;
 
+const RedirectIconWrapper = styled.div`
+  & > :hover {
+    color: ${({ theme }) => theme.text1};
+    cursor: pointer;
+  }
+`;
+
 const PanelLoaderWrapper = ({ maxHeight, isLoading, children }) => (
   <Panel maxHeight={maxHeight || '380px'}>{isLoading ? <LocalLoader /> : children}</Panel>
 );
@@ -54,11 +63,12 @@ const CardLoaderWrapper = ({ isLoading, children }) => (
   <Panel padding={'32px 36px'}>{isLoading ? <LocalLoader height={'163px'} /> : children}</Panel>
 );
 
-const DashboardPage = () => {
+const DashboardPage = ({ history }) => {
   const oneDayTransactions = useOneDaySwapsData();
   const oneDayWalletsData = useOneDayWalletsData();
   const chartData = useDashboardChartData();
   const comulativeData = useDashboardComulativeData();
+  const switchNetwork = useSelectedNetworkUpdater();
   const { uncollectedFeesData, loading: isLoadingUncollectedFees } = useUncollectedFeesData();
 
   const [formattedLiquidityData, setFormattedLiquidityData] = useState([]);
@@ -68,6 +78,11 @@ const DashboardPage = () => {
   // breakpoints
   const below800 = useMedia('(max-width: 800px)');
   const below1400 = useMedia('(max-width: 1400px)');
+
+  const handleReceiverLookup = (network) => {
+    switchNetwork(network);
+    history.push(`/account/${NETOWRK_FEE_RECEIVER_ADDRESSES[network]}`);
+  };
 
   useEffect(() => {
     if (chartData && chartData.daily) {
@@ -179,6 +194,11 @@ const DashboardPage = () => {
                     icon={<Icon icon={<Zap size={16} />} />}
                     comulativeValue={`$ ${formattedNum(uncollectedFeesData?.total ?? 0)}`}
                     networksValues={formattedUncollectedFees}
+                    customNetworkAction={
+                      <RedirectIconWrapper onClick={handleReceiverLookup}>
+                        <Icon icon={<Link size={14} />} color={'text6'} />
+                      </RedirectIconWrapper>
+                    }
                   />
                 </CardLoaderWrapper>
                 <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
@@ -225,13 +245,17 @@ const DashboardPage = () => {
                       networksValues={formattedComulativeData.trades}
                     />
                   </CardLoaderWrapper>
-
                   <CardLoaderWrapper isLoading={isLoadingUncollectedFees}>
                     <ComulativeNetworkDataCard
                       title={'Uncollected fees'}
                       icon={<Icon icon={<Zap size={16} />} />}
                       comulativeValue={`$ ${formattedNum(uncollectedFeesData?.total ?? 0)}`}
                       networksValues={formattedUncollectedFees}
+                      customNetworkAction={
+                        <RedirectIconWrapper onClick={handleReceiverLookup}>
+                          <Icon icon={<Link size={14} />} color={'text6'} />
+                        </RedirectIconWrapper>
+                      }
                     />
                   </CardLoaderWrapper>
                   <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
@@ -288,6 +312,11 @@ const DashboardPage = () => {
                         icon={<Icon icon={<Zap size={16} />} />}
                         comulativeValue={`$ ${formattedNum(uncollectedFeesData?.total ?? 0)}`}
                         networksValues={formattedUncollectedFees}
+                        customNetworkAction={
+                          <RedirectIconWrapper onClick={handleReceiverLookup}>
+                            <Icon icon={<Link size={14} />} color={'text6'} />
+                          </RedirectIconWrapper>
+                        }
                       />
                     </CardLoaderWrapper>
                     <CardLoaderWrapper isLoading={isLoadingOneDayTransactions}>
@@ -319,4 +348,4 @@ const DashboardPage = () => {
   );
 };
 
-export default DashboardPage;
+export default withRouter(DashboardPage);

--- a/src/pages/GlobalPage.js
+++ b/src/pages/GlobalPage.js
@@ -149,7 +149,7 @@ function GlobalPage() {
           </Panel>
           <ListOptions gap="10px" style={{ marginTop: '2rem', marginBottom: '.5rem' }}>
             <RowBetween>
-              <TYPE.main fontSize={'1rem'}>Top Pairs</TYPE.main>
+              <TYPE.main ffontSize={'1.125rem'}>Top Pairs</TYPE.main>
               <CustomLink to={'/pairs'}>See All</CustomLink>
             </RowBetween>
           </ListOptions>


### PR DESCRIPTION
# Summary

Add a redirect link to the fee receivers of each network from the `Dashboard`, inside the `Uncollected fees` card.
This PR also fixes a few queries that were failing due to a too large payload and an error when caching the query.

[scrnli_7_14_2022_9-16-10 PM.webm](https://user-images.githubusercontent.com/9011637/179065270-2a1db714-1582-476e-a097-9969b45631e2.webm)

# How To Test
1.  Open the page `Dashboard`
- [ ] On the `Uncollected fees` card there are 3 icons, clicking them should cause a redirect to the account page for the receiver address