### PR TITLE
feat/redesign tokens page

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-device-detect": "^1.9.10",
     "react-dom": "^17.0.2",
     "react-fast-compare": "^3.2.0",
+    "react-fast-marquee": "^1.3.5",
     "react-feather": "^2.0.3",
     "react-iframe": "^1.8.0",
     "react-loading-skeleton": "^3.1.0",

--- a/src/Theme/index.jsx
+++ b/src/Theme/index.jsx
@@ -153,6 +153,18 @@ export const Typography = {
       {children}
     </TextWrapper>
   ),
+  BoldText: ({ color, children, sx, className }) => (
+    <TextWrapper
+      fontWeight={600}
+      fontSize={13}
+      lineHeight={'16px'}
+      color={color || 'text1'}
+      sx={sx}
+      className={className}
+    >
+      {children}
+    </TextWrapper>
+  ),
   LargeText: ({ color, children, sx, className }) => (
     <TextWrapper
       fontWeight={400}
@@ -182,6 +194,18 @@ export const Typography = {
       fontWeight={400}
       fontSize={16}
       lineHeight={'19px'}
+      color={color || 'text1'}
+      sx={sx}
+      className={className}
+    >
+      {children}
+    </TextWrapper>
+  ),
+  MediumHeader: ({ color, children, sx, className }) => (
+    <TextWrapper
+      fontWeight={400}
+      fontSize={20}
+      lineHeight={'24px'}
       color={color || 'text1'}
       sx={sx}
       className={className}

--- a/src/components/LocalLoader/index.jsx
+++ b/src/components/LocalLoader/index.jsx
@@ -29,7 +29,9 @@ const Wrapper = styled.div`
 `;
 
 const AnimatedImg = styled.div`
+  height: 64px;
   animation: ${pulse} 800ms linear infinite;
+
   & > * {
     width: 64px;
   }

--- a/src/components/TokenCard/index.jsx
+++ b/src/components/TokenCard/index.jsx
@@ -5,9 +5,9 @@ import { formattedNum, formattedPercent } from '../../utils';
 import TokenLogo from '../TokenLogo';
 import { PercentageChange, Wrapper } from './styled';
 
-const TokenCard = ({ address, symbol, price, priceChange }) => {
+const TokenCard = ({ address, symbol, price, priceChange, margin }) => {
   return (
-    <Wrapper isNegative={priceChange < 0}>
+    <Wrapper isNegative={priceChange < 0} margin={margin}>
       <TokenLogo address={address} />
       <div>
         <Typography.Text color={'text8'}>{symbol}</Typography.Text>
@@ -23,6 +23,7 @@ TokenCard.propTypes = {
   symbol: PropTypes.string,
   price: PropTypes.number,
   priceChange: PropTypes.number,
+  margin: PropTypes.string,
 };
 
 export default TokenCard;

--- a/src/components/TokenCard/index.jsx
+++ b/src/components/TokenCard/index.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+
+import { Typography } from '../../Theme';
+import { formattedNum, formattedPercent } from '../../utils';
+import TokenLogo from '../TokenLogo';
+import { PercentageChange, Wrapper } from './styled';
+
+const TokenCard = ({ address, symbol, price, priceChange }) => {
+  return (
+    <Wrapper isNegative={priceChange < 0}>
+      <TokenLogo address={address} />
+      <div>
+        <Typography.Text color={'text8'}>{symbol}</Typography.Text>
+        <Typography.BoldText color={'text9'}>{formattedNum(price, true)}</Typography.BoldText>
+      </div>
+      <PercentageChange>{formattedPercent(priceChange)}</PercentageChange>
+    </Wrapper>
+  );
+};
+
+TokenCard.propTypes = {
+  address: PropTypes.string,
+  symbol: PropTypes.string,
+  price: PropTypes.number,
+  priceChange: PropTypes.number,
+};
+
+export default TokenCard;

--- a/src/components/TokenCard/styled.jsx
+++ b/src/components/TokenCard/styled.jsx
@@ -6,6 +6,7 @@ const Wrapper = styled.div`
   gap: 10px;
   padding: 20px;
   height: 26px;
+  min-width: 150px;
   border-radius: 12px;
   box-shadow: ${({ theme }) => `0px 0.5px 0px 0.1px ${theme.bd1}`};
 

--- a/src/components/TokenCard/styled.jsx
+++ b/src/components/TokenCard/styled.jsx
@@ -10,7 +10,7 @@ const Wrapper = styled.div`
   min-width: 150px;
   border-radius: 12px;
   box-shadow: ${({ theme }) => `0px 0.5px 0px 0.1px ${theme.bd1}`};
-
+  margin: ${({ margin }) => (margin ? `${margin}` : '0')};
   background: ${({ isNegative }) =>
     isNegative
       ? `linear-gradient(226.13deg, rgba(152, 15, 15, 0.2) -7.71%, rgba(152, 15, 15, 0) 85.36%), linear-gradient(113.18deg, rgba(255, 255, 255, 0.15) -0.1%, rgba(0, 0, 0, 0) 98.9%), #0C0B11`

--- a/src/components/TokenCard/styled.jsx
+++ b/src/components/TokenCard/styled.jsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px;
+  height: 26px;
+  border-radius: 12px;
+  box-shadow: ${({ theme }) => `0px 0.5px 0px 0.1px ${theme.bd1}`};
+
+  background: ${({ isNegative }) =>
+    isNegative
+      ? `linear-gradient(226.13deg, rgba(152, 15, 15, 0.2) -7.71%, rgba(152, 15, 15, 0) 85.36%), linear-gradient(113.18deg, rgba(255, 255, 255, 0.15) -0.1%, rgba(0, 0, 0, 0) 98.9%), #0C0B11`
+      : `linear-gradient(226.13deg, rgba(15, 152, 106, 0.2) -7.71%, rgba(15, 152, 106, 0) 85.36%),
+  linear-gradient(113.18deg, rgba(255, 255, 255, 0.15) -0.1%, rgba(0, 0, 0, 0) 98.9%), #0c0b11`};
+  background-blend-mode: normal, overlay, normal;
+`;
+
+const PercentageChange = styled.div`
+  margin-top: 16px;
+
+  & > div {
+    font-size: 13px;
+    line-height: 14px;
+    font-weight: 600;
+  }
+`;
+
+export { PercentageChange, Wrapper };

--- a/src/components/TokenCard/styled.jsx
+++ b/src/components/TokenCard/styled.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const Wrapper = styled.div`
   display: flex;
+  justify-content: space-evenly;
   align-items: center;
   gap: 10px;
   padding: 20px;

--- a/src/components/TokenList/index.jsx
+++ b/src/components/TokenList/index.jsx
@@ -27,8 +27,8 @@ const List = styled(Box)`
 const DashGrid = styled.div`
   display: grid;
   grid-gap: 1em;
-  grid-template-columns: 100px 1fr;
-  grid-template-areas: 'name vol';
+  grid-template-columns: 100px 1fr 1fr;
+  grid-template-areas: 'name price vol';
   padding: 0 36px;
 
   > * {
@@ -43,8 +43,8 @@ const DashGrid = styled.div`
   @media screen and (min-width: 680px) {
     display: grid;
     grid-gap: 1em;
-    grid-template-columns: 180px 1fr 1fr 1fr;
-    grid-template-areas: 'name symbol liq vol';
+    grid-template-columns: 180px 1fr 1fr 1fr 1fr;
+    grid-template-areas: 'name symbol price liq vol';
 
     > * {
       justify-content: flex-end;
@@ -171,7 +171,7 @@ function TopTokenList({ tokens, itemMax = 10 }) {
             <FormattedName text={item.symbol} maxCharacters={5} />
           </FlexText>
         )}
-        {!below1080 && <FlexText area={'price'}>{formattedNum(item.priceUSD, true)}</FlexText>}
+        <FlexText area={'price'}>{formattedNum(item.priceUSD, true)}</FlexText>
         {!below1080 && <FlexText area={'change'}>{formattedPercent(item.priceChangeUSD)}</FlexText>}
         {!below680 && (
           <FlexText color={'text1'} area={'liq'}>
@@ -224,21 +224,19 @@ function TopTokenList({ tokens, itemMax = 10 }) {
               </ClickableText>
             </Flex>
           )}
-          {!below1080 && (
-            <Flex alignItems="center">
-              <ClickableText
-                area="price"
-                onClick={() => {
-                  setSortedColumn(SORT_FIELD.PRICE);
-                  setSortDirection(sortedColumn !== SORT_FIELD.PRICE ? true : !sortDirection);
-                }}
-              >
-                <Typography.SmallBoldText color={'text8'} sx={{ textTransform: 'uppercase' }}>
-                  Price {sortedColumn === SORT_FIELD.PRICE ? (!sortDirection ? '↑' : '↓') : ''}
-                </Typography.SmallBoldText>
-              </ClickableText>
-            </Flex>
-          )}
+          <Flex alignItems="center">
+            <ClickableText
+              area="price"
+              onClick={() => {
+                setSortedColumn(SORT_FIELD.PRICE);
+                setSortDirection(sortedColumn !== SORT_FIELD.PRICE ? true : !sortDirection);
+              }}
+            >
+              <Typography.SmallBoldText color={'text8'} sx={{ textTransform: 'uppercase' }}>
+                Price {sortedColumn === SORT_FIELD.PRICE ? (!sortDirection ? '↑' : '↓') : ''}
+              </Typography.SmallBoldText>
+            </ClickableText>
+          </Flex>
           {!below1080 && (
             <Flex alignItems="center">
               <ClickableText

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -154,7 +154,7 @@ export const FullWrapper = styled.div`
   justify-content: start;
   align-items: start;
   grid-template-columns: 1fr;
-  grid-gap: 24px;
+  grid-gap: ${({ gap }) => gap ?? '24px'};
   max-width: 1440px;
   width: 100%;
   margin: 0 auto;

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -14,7 +14,6 @@ import { useAllTokenData } from '../contexts/TokenData';
 
 export const ScrollableRow = styled.div`
   display: flex;
-  justify-content: space-evenly;
   flex-direction: row;
   overflow-x: auto;
   white-space: nowrap;

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -13,15 +13,6 @@ import TokenCard from '../components/TokenCard';
 import TopTokenList from '../components/TokenList';
 import { useAllTokenData } from '../contexts/TokenData';
 
-export const ScrollableRow = styled.div`
-  overflow-x: auto;
-  gap: 14px;
-  padding: 20px;
-  border-radius: 8px;
-  border: 1px solid ${({ theme }) => theme.bd1};
-  background-color: ${({ theme }) => theme.bg7};
-`;
-
 function AllTokensPage() {
   const allTokens = useAllTokenData();
 
@@ -50,7 +41,7 @@ function AllTokensPage() {
           {!below800 && <Search small={true} />}
         </Flex>
         {!isTopMoversEmpty && (
-          <ScrollableRow>
+          <>
             {topMovers.length > 0 ? (
               <Marquee
                 gradient
@@ -74,7 +65,7 @@ function AllTokensPage() {
             ) : (
               <LocalLoader height={'26px'} />
             )}
-          </ScrollableRow>
+          </>
         )}
         {below800 && (
           <Box marginTop={'20px'}>

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useMemo } from 'react';
 import 'feather-icons';
 import { useMedia } from 'react-use';
-import { Flex } from 'rebass';
+import { Box, Flex } from 'rebass';
 import styled from 'styled-components';
 
 import { Typography } from '../Theme';
@@ -14,12 +14,14 @@ import { useAllTokenData } from '../contexts/TokenData';
 
 export const ScrollableRow = styled.div`
   display: flex;
+  justify-content: space-evenly;
   flex-direction: row;
   overflow-x: auto;
   white-space: nowrap;
   gap: 14px;
   padding: 20px;
   border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.bd1};
   background-color: ${({ theme }) => theme.bg7};
 
   ::-webkit-scrollbar {
@@ -69,13 +71,11 @@ function AllTokensPage() {
 
   return (
     <PageWrapper>
-      <FullWrapper>
-        {!below800 && (
-          <Flex alignItems={'flex-end'} justifyContent={'space-between'}>
-            <Typography.MediumHeader color={'text10'}>Top Movers</Typography.MediumHeader>
-            <Search small={true} />
-          </Flex>
-        )}
+      <FullWrapper gap={'0'}>
+        <Flex alignItems={'center'} justifyContent={below800 ? 'center' : 'space-between'} marginBottom={'16px'}>
+          <Typography.MediumHeader color={'text10'}>Top Movers</Typography.MediumHeader>
+          {!below800 && <Search small={true} />}
+        </Flex>
         <ScrollableRow ref={increaseRef}>
           {topMovers.length > 0 ? (
             topMovers.map((token) => (
@@ -91,7 +91,17 @@ function AllTokensPage() {
             <LocalLoader height={'26px'} />
           )}
         </ScrollableRow>
-        <Typography.MediumHeader color={'text10'}>Top Tokens</Typography.MediumHeader>
+        {below800 && (
+          <Box marginTop={'20px'}>
+            <Search small={true} />
+          </Box>
+        )}
+        <Typography.MediumHeader
+          color={'text10'}
+          sx={{ textAlign: below800 ? 'center' : 'left', marginTop: '40px', marginBottom: '20px' }}
+        >
+          Top Tokens
+        </Typography.MediumHeader>
         <TopTokenList tokens={allTokens} itemMax={20} />
       </FullWrapper>
     </PageWrapper>

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import 'feather-icons';
 import Marquee from 'react-fast-marquee';
 import { useMedia } from 'react-use';
 import { Box, Flex } from 'rebass';
+import styled from 'styled-components';
 
 import { Typography } from '../Theme';
 import { PageWrapper, FullWrapper } from '../components';
@@ -12,33 +13,23 @@ import TokenCard from '../components/TokenCard';
 import TopTokenList from '../components/TokenList';
 import { useAllTokenData } from '../contexts/TokenData';
 
+export const ScrollableRow = styled.div`
+  overflow-x: auto;
+  gap: 14px;
+  padding: 20px;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.bd1};
+  background-color: ${({ theme }) => theme.bg7};
+`;
+
 function AllTokensPage() {
   const allTokens = useAllTokenData();
-  const increaseRef = useRef(null);
+
   const below800 = useMedia('(max-width: 800px)');
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
-
-  useEffect(() => {
-    let interval;
-
-    if (Object.values(allTokens).length > 0 && increaseRef && increaseRef.current) {
-      setTimeout(() => {
-        interval = setInterval(() => {
-          if (
-            increaseRef.current &&
-            increaseRef.current.scrollLeft + increaseRef.current.offsetWidth < increaseRef.current.scrollWidth
-          ) {
-            increaseRef.current.scrollTo(increaseRef.current.scrollLeft + 1, 0);
-          }
-        }, 50);
-      }, 3000);
-    }
-
-    return () => clearInterval(interval);
-  }, [increaseRef, allTokens]);
 
   const topMovers = useMemo(
     () =>
@@ -49,40 +40,42 @@ function AllTokensPage() {
     [allTokens],
   );
 
-  if (topMovers.length === 0) {
-    return null;
-  }
+  const isTopMoversEmpty = Object.keys(allTokens).length > 0 && topMovers.length === 0;
 
   return (
     <PageWrapper>
       <FullWrapper gap={'0'}>
         <Flex alignItems={'center'} justifyContent={below800 ? 'center' : 'space-between'} marginBottom={'16px'}>
-          <Typography.MediumHeader color={'text10'}>Top Movers</Typography.MediumHeader>
+          {!isTopMoversEmpty ? <Typography.MediumHeader color={'text10'}>Top Movers</Typography.MediumHeader> : <div />}
           {!below800 && <Search small={true} />}
         </Flex>
-        <Marquee
-          gradient
-          gradientWidth={below800 ? 10 : 30}
-          gradientColor={[11, 11, 17]}
-          speed={40}
-          style={{ margin: '5px 0px', height: 'fit-content' }}
-          pauseOnHover
-        >
-          {topMovers.length > 0 ? (
-            topMovers.map((token) => (
-              <TokenCard
-                key={token.id}
-                address={token.id}
-                symbol={token.symbol}
-                price={token.priceUSD}
-                priceChange={token.priceChangeUSD}
-                margin="0px 5px"
-              />
-            ))
-          ) : (
-            <LocalLoader height={'26px'} />
-          )}
-        </Marquee>
+        {!isTopMoversEmpty && (
+          <ScrollableRow>
+            {topMovers.length > 0 ? (
+              <Marquee
+                gradient
+                gradientWidth={below800 ? 10 : 30}
+                gradientColor={[11, 11, 17]}
+                speed={40}
+                style={{ margin: '5px 0px', height: 'fit-content' }}
+                pauseOnHover
+              >
+                {topMovers.map((token) => (
+                  <TokenCard
+                    key={token.id}
+                    address={token.id}
+                    symbol={token.symbol}
+                    price={token.priceUSD}
+                    priceChange={token.priceChangeUSD}
+                    margin="0px 5px"
+                  />
+                ))}
+              </Marquee>
+            ) : (
+              <LocalLoader height={'26px'} />
+            )}
+          </ScrollableRow>
+        )}
         {below800 && (
           <Box marginTop={'20px'}>
             <Search small={true} />

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -3,7 +3,6 @@ import 'feather-icons';
 import Marquee from 'react-fast-marquee';
 import { useMedia } from 'react-use';
 import { Box, Flex } from 'rebass';
-import styled from 'styled-components';
 
 import { Typography } from '../Theme';
 import { PageWrapper, FullWrapper } from '../components';

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -43,7 +43,7 @@ function AllTokensPage() {
   useEffect(() => {
     let interval;
 
-    if (increaseRef && increaseRef.current) {
+    if (Object.values(allTokens).length > 0 && increaseRef && increaseRef.current) {
       setTimeout(() => {
         interval = setInterval(() => {
           if (
@@ -57,7 +57,7 @@ function AllTokensPage() {
     }
 
     return () => clearInterval(interval);
-  }, [increaseRef]);
+  }, [increaseRef, allTokens]);
 
   const topMovers = useMemo(
     () =>

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useMemo } from 'react';
 import 'feather-icons';
+import Marquee from 'react-fast-marquee';
 import { useMedia } from 'react-use';
 import { Box, Flex } from 'rebass';
-import styled from 'styled-components';
 
 import { Typography } from '../Theme';
 import { PageWrapper, FullWrapper } from '../components';
@@ -11,21 +11,6 @@ import Search from '../components/Search';
 import TokenCard from '../components/TokenCard';
 import TopTokenList from '../components/TokenList';
 import { useAllTokenData } from '../contexts/TokenData';
-
-export const ScrollableRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  overflow-x: auto;
-  white-space: nowrap;
-  gap: 14px;
-  padding: 20px;
-  border-radius: 8px;
-  border: 1px solid ${({ theme }) => theme.bd1};
-  background-color: ${({ theme }) => theme.bg7};
-
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-`;
 
 function AllTokensPage() {
   const allTokens = useAllTokenData();
@@ -64,6 +49,10 @@ function AllTokensPage() {
     [allTokens],
   );
 
+  if (topMovers.length === 0) {
+    return null;
+  }
+
   return (
     <PageWrapper>
       <FullWrapper gap={'0'}>
@@ -71,7 +60,14 @@ function AllTokensPage() {
           <Typography.MediumHeader color={'text10'}>Top Movers</Typography.MediumHeader>
           {!below800 && <Search small={true} />}
         </Flex>
-        <ScrollableRow ref={increaseRef}>
+        <Marquee
+          gradient
+          gradientWidth={below800 ? 10 : 30}
+          gradientColor={[11, 11, 17]}
+          speed={40}
+          style={{ margin: '5px 0px', height: 'fit-content' }}
+          pauseOnHover
+        >
           {topMovers.length > 0 ? (
             topMovers.map((token) => (
               <TokenCard
@@ -80,12 +76,13 @@ function AllTokensPage() {
                 symbol={token.symbol}
                 price={token.priceUSD}
                 priceChange={token.priceChangeUSD}
+                margin="0px 5px"
               />
             ))
           ) : (
             <LocalLoader height={'26px'} />
           )}
-        </ScrollableRow>
+        </Marquee>
         {below800 && (
           <Box marginTop={'20px'}>
             <Search small={true} />

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -23,10 +23,6 @@ export const ScrollableRow = styled.div`
   border: 1px solid ${({ theme }) => theme.bd1};
   background-color: ${({ theme }) => theme.bg7};
 
-  ::-webkit-scrollbar {
-    display: none;
-  }
-
   -ms-overflow-style: none;
   scrollbar-width: none;
 `;

--- a/src/pages/AllTokensPage.jsx
+++ b/src/pages/AllTokensPage.jsx
@@ -1,30 +1,97 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import 'feather-icons';
 import { useMedia } from 'react-use';
 import { Flex } from 'rebass';
+import styled from 'styled-components';
 
 import { Typography } from '../Theme';
 import { PageWrapper, FullWrapper } from '../components';
+import LocalLoader from '../components/LocalLoader';
 import Search from '../components/Search';
+import TokenCard from '../components/TokenCard';
 import TopTokenList from '../components/TokenList';
 import { useAllTokenData } from '../contexts/TokenData';
 
+export const ScrollableRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  overflow-x: auto;
+  white-space: nowrap;
+  gap: 14px;
+  padding: 20px;
+  border-radius: 8px;
+  background-color: ${({ theme }) => theme.bg7};
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
 function AllTokensPage() {
   const allTokens = useAllTokenData();
+  const increaseRef = useRef(null);
+  const below800 = useMedia('(max-width: 800px)');
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  const below600 = useMedia('(max-width: 800px)');
+  useEffect(() => {
+    let interval;
+
+    if (increaseRef && increaseRef.current) {
+      setTimeout(() => {
+        interval = setInterval(() => {
+          if (
+            increaseRef.current &&
+            increaseRef.current.scrollLeft + increaseRef.current.offsetWidth < increaseRef.current.scrollWidth
+          ) {
+            increaseRef.current.scrollTo(increaseRef.current.scrollLeft + 1, 0);
+          }
+        }, 50);
+      }, 3000);
+    }
+
+    return () => clearInterval(interval);
+  }, [increaseRef]);
+
+  const topMovers = useMemo(
+    () =>
+      Object.values(allTokens)
+        .sort((a, b) => Math.abs(b.priceChangeUSD) - Math.abs(a.priceChangeUSD))
+        .slice(0, 20)
+        .filter((token) => Number(Math.abs(token.priceChangeUSD)).toFixed(2) !== '0.00'),
+    [allTokens],
+  );
 
   return (
     <PageWrapper>
       <FullWrapper>
-        <Flex alignItems={'flex-end'} justifyContent={'space-between'}>
-          <Typography.LargeHeader>Top Tokens</Typography.LargeHeader>
-          {!below600 && <Search small={true} />}
-        </Flex>
+        {!below800 && (
+          <Flex alignItems={'flex-end'} justifyContent={'space-between'}>
+            <Typography.MediumHeader color={'text10'}>Top Movers</Typography.MediumHeader>
+            <Search small={true} />
+          </Flex>
+        )}
+        <ScrollableRow ref={increaseRef}>
+          {topMovers.length > 0 ? (
+            topMovers.map((token) => (
+              <TokenCard
+                key={token.id}
+                address={token.id}
+                symbol={token.symbol}
+                price={token.priceUSD}
+                priceChange={token.priceChangeUSD}
+              />
+            ))
+          ) : (
+            <LocalLoader height={'26px'} />
+          )}
+        </ScrollableRow>
+        <Typography.MediumHeader color={'text10'}>Top Tokens</Typography.MediumHeader>
         <TopTokenList tokens={allTokens} itemMax={20} />
       </FullWrapper>
     </PageWrapper>

--- a/src/pages/GlobalPage.jsx
+++ b/src/pages/GlobalPage.jsx
@@ -122,21 +122,15 @@ const GlobalPage = () => {
           )}
           <GlobalStats />
           <ListOptions gap="10px" style={{ marginTop: '40px', marginBottom: '20px' }}>
-            <Typography.Custom color={'text10'} sx={{ fontSize: '20px', lineHeight: '24px', fontWeight: 400 }}>
-              Top Tokens
-            </Typography.Custom>
+            <Typography.MediumHeader color={'text10'}>Top Tokens</Typography.MediumHeader>
           </ListOptions>
           <TopTokenList tokens={allTokens} />
           <ListOptions gap="10px" style={{ marginTop: '40px', marginBottom: '20px' }}>
-            <Typography.Custom color={'text10'} sx={{ fontSize: '20px', lineHeight: '24px', fontWeight: 400 }}>
-              Top Pairs
-            </Typography.Custom>
+            <Typography.MediumHeader color={'text10'}>Top Pairs</Typography.MediumHeader>
           </ListOptions>
           <PairList pairs={allPairs} />
           <ListOptions gap="10px" style={{ marginTop: '40px', marginBottom: '20px' }}>
-            <Typography.Custom color={'text10'} sx={{ fontSize: '20px', lineHeight: '24px', fontWeight: 400 }}>
-              Transactions
-            </Typography.Custom>
+            <Typography.MediumHeader color={'text10'}>Transactions</Typography.MediumHeader>
           </ListOptions>
           <TxnList transactions={transactions} />
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10814,6 +10814,11 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-fast-marquee@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/react-fast-marquee/-/react-fast-marquee-1.3.5.tgz#e53995027102fbec92da90606d7ca89703db9903"
+  integrity sha512-eOqLoz4iVVBvi2wN/web8hd2XX9y2Z6CYR7g++7nTVHlTOXBtqyARQJ9rYNpbp179hAzloMx0yBFAo8LpNYmKQ==
+
 react-feather@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.10.tgz#0e9abf05a66754f7b7bb71757ac4da7fb6be3b68"


### PR DESCRIPTION
# Summary

Fixes #97

Redesign the `tokens` page accordingly to the new Figma designs.

New components that show the top movers tokens (limited to 20 tokens):
![image](https://user-images.githubusercontent.com/9011637/184336128-9d1e4ee1-c92e-4cdc-a3d3-98f4e7a9c382.png)

New list:
![image](https://user-images.githubusercontent.com/9011637/184336473-345390e1-8341-4d46-95a5-e53eb907d190.png)

# How To Test
1.  Open the page `tokens`
- [ ] Verify it contains the `top movers` component and that the scroll starts after a couple of seconds